### PR TITLE
Fix FBO pipeline warnings and mipmap errors

### DIFF
--- a/benchmark/src/pipeline_test.c
+++ b/benchmark/src/pipeline_test.c
@@ -42,6 +42,10 @@ void run_pipeline_test(Framebuffer *fb, BenchmarkResult *result)
 	}
 	clock_t end = clock();
 
+	/* Ensure the FBO is still bound before generating mipmaps. Some
+         * benchmark helpers may reset the binding when syncing threads or
+         * updating lighting state. */
+	glBindFramebufferOES(GL_FRAMEBUFFER_OES, fbo);
 	glGenerateMipmapOES(GL_TEXTURE_2D);
 
 	glBindFramebufferOES(GL_FRAMEBUFFER_OES, 0);

--- a/src/extensions/gl_ext_OES_framebuffer_object.c
+++ b/src/extensions/gl_ext_OES_framebuffer_object.c
@@ -4,6 +4,7 @@
 #include "gl_state.h"
 #include "gl_types.h"
 #include "gl_utils.h"
+#include "gl_context.h"
 #include "gl_ext_common.h"
 EXT_REGISTER("GL_OES_framebuffer_object")
 int ext_link_dummy_OES_framebuffer_object;
@@ -998,22 +999,15 @@ GL_API void GL_APIENTRY glGenerateMipmapOES(GLenum target)
 		return;
 	}
 
-	FramebufferOES *fb = gl_state.bound_framebuffer;
-	if (fb == NULL) {
+	/* The spec operates on the texture currently bound to the active unit. */
+	RenderContext *ctx = GetCurrentContext();
+	GLuint tex_id = ctx->texture_env[ctx->active_texture - GL_TEXTURE0]
+				.bound_texture;
+	TextureOES *tex = context_find_texture(tex_id);
+	if (!tex) {
 		LOG_ERROR(
-			"glGenerateMipmapOES: No framebuffer is currently bound.");
-		glSetError(GL_INVALID_OPERATION);
-		return;
-	}
-
-	TextureOES *tex = NULL;
-	if (fb->color_attachment.type == ATTACHMENT_TEXTURE) {
-		tex = fb->color_attachment.attachment.texture;
-	}
-
-	if (tex == NULL) {
-		LOG_ERROR("glGenerateMipmapOES: No texture is attached to the "
-			  "framebuffer's color attachment.");
+			"glGenerateMipmapOES: No texture bound to active unit %d.",
+			ctx->active_texture - GL_TEXTURE0);
 		glSetError(GL_INVALID_OPERATION);
 		return;
 	}

--- a/src/gl_context.c
+++ b/src/gl_context.c
@@ -552,6 +552,9 @@ void context_tex_image_2d(GLenum target, GLint level, GLint internalformat,
 	if (level == 0) {
 		tex->width = width;
 		tex->height = height;
+		tex->mipmap_supported = (width > 0 && height > 0 &&
+					 (width & (width - 1)) == 0 &&
+					 (height & (height - 1)) == 0);
 	}
 	if (level > tex->current_level)
 		tex->current_level = level;

--- a/src/matrix_utils.c
+++ b/src/matrix_utils.c
@@ -24,7 +24,10 @@ void vec3_normalize(GLfloat *x, GLfloat *y, GLfloat *z)
 		*y /= length;
 		*z /= length;
 	} else {
-		LOG_WARN("vec3_normalize: Zero-length vector encountered.");
+		/* Avoid spamming the logs when normalizing a zero vector. */
+		*x = 0.0f;
+		*y = 0.0f;
+		*z = 0.0f;
 	}
 }
 

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -100,11 +100,14 @@ static void apply_lighting(Vertex *v)
 		float hx = lx;
 		float hy = ly;
 		float hz = lz + 1.0f;
-		vec3_normalize(&hx, &hy, &hz);
-		float spec_dot = nx * hx + ny * hy + nz * hz;
-		if (spec_dot < 0.0f)
-			spec_dot = 0.0f;
-		float spec = powf(spec_dot, tl_mat.shininess);
+		float spec = 0.0f;
+		if (hx != 0.0f || hy != 0.0f || hz != 0.0f) {
+			vec3_normalize(&hx, &hy, &hz);
+			float spec_dot = nx * hx + ny * hy + nz * hz;
+			if (spec_dot < 0.0f)
+				spec_dot = 0.0f;
+			spec = powf(spec_dot, tl_mat.shininess);
+		}
 		r += tl_mat.ambient[0] * lt->ambient[0] * att +
 		     tl_mat.diffuse[0] * lt->diffuse[0] * dot * att +
 		     tl_mat.specular[0] * lt->specular[0] * spec * att;


### PR DESCRIPTION
## Summary
- ensure pipeline benchmark rebinds FBO before calling `glGenerateMipmapOES`
- silence zero-vector warnings in `vec3_normalize`
- avoid zero-normalized half vectors in lighting calculations
- correct `glGenerateMipmapOES` to operate on currently bound texture
- mark textures as mipmap capable when created

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/benchmark`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6850438be4e88325a29a86dc368cb852