### PR TITLE
Improve glDrawElements primitive assembly

### DIFF
--- a/src/gl_api_draw.c
+++ b/src/gl_api_draw.c
@@ -272,6 +272,7 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 							      sizeof(GLushort);
 		if (offset + elem_size * (size_t)count > (size_t)obj->size) {
 			glSetError(GL_INVALID_OPERATION);
+			PROFILE_END("glDrawElements");
 			return;
 		}
 		if (type == GL_UNSIGNED_BYTE)
@@ -287,11 +288,189 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 			u16_indices = (const GLushort *)indices;
 	}
 
-	for (GLsizei i = 0; i < count; ++i) {
-		GLuint idx = (type == GL_UNSIGNED_BYTE) ?
-				     (GLuint)u8_indices[i] :
-				     (GLuint)u16_indices[i];
-		glDrawArrays(mode, (GLint)idx, 1);
+	RenderContext *ctx = GetCurrentContext();
+	if (!ctx->vertex_array.enabled) {
+		glSetError(GL_INVALID_OPERATION);
+		PROFILE_END("glDrawElements");
+		return;
+	}
+
+	GLsizei vstride =
+		ctx->vertex_array.stride ?
+			ctx->vertex_array.stride :
+			(GLsizei)(ctx->vertex_array.size * sizeof(GLfloat));
+	GLsizei nstride = ctx->normal_array.stride ?
+				  ctx->normal_array.stride :
+				  (GLsizei)(3 * sizeof(GLfloat));
+	GLsizei cstride = ctx->color_array.stride ?
+				  ctx->color_array.stride :
+				  (GLsizei)(ctx->color_array.size *
+					    (ctx->color_array.type == GL_FLOAT ?
+						     sizeof(GLfloat) :
+						     sizeof(GLubyte)));
+	GLsizei tstride =
+		ctx->texcoord_array.stride ?
+			ctx->texcoord_array.stride :
+			(GLsizei)(ctx->texcoord_array.size * sizeof(GLfloat));
+
+	const uint8_t *vptr = (const uint8_t *)ctx->vertex_array.pointer;
+	const uint8_t *nptr = (const uint8_t *)ctx->normal_array.pointer;
+	const uint8_t *cptr = (const uint8_t *)ctx->color_array.pointer;
+	const uint8_t *tptr = (const uint8_t *)ctx->texcoord_array.pointer;
+
+	BufferObject *array_obj = NULL;
+	if (gl_state.array_buffer_binding) {
+		array_obj = find_buffer(gl_state.array_buffer_binding);
+		if (!array_obj || !array_obj->data) {
+			glSetError(GL_INVALID_OPERATION);
+			PROFILE_END("glDrawElements");
+			return;
+		}
+		GLuint max_idx = 0;
+		for (GLsizei i = 0; i < count; ++i) {
+			GLuint idx = type == GL_UNSIGNED_BYTE ?
+					     (GLuint)u8_indices[i] :
+					     (GLuint)u16_indices[i];
+			if (idx > max_idx)
+				max_idx = idx;
+		}
+		size_t needed = (size_t)ctx->vertex_array.pointer +
+				(size_t)(max_idx + 1) * vstride;
+		if (needed > (size_t)array_obj->size) {
+			glSetError(GL_INVALID_OPERATION);
+			PROFILE_END("glDrawElements");
+			return;
+		}
+
+		vptr = (const uint8_t *)array_obj->data + (size_t)vptr;
+		nptr = (const uint8_t *)array_obj->data + (size_t)nptr;
+		cptr = (const uint8_t *)array_obj->data + (size_t)cptr;
+		tptr = (const uint8_t *)array_obj->data + (size_t)tptr;
+	}
+
+	Framebuffer *fb = NULL;
+	if (gl_state.bound_framebuffer)
+		fb = gl_state.bound_framebuffer->fb;
+	if (!fb)
+		fb = GL_get_default_framebuffer();
+	if (!fb) {
+		PROFILE_END("glDrawElements");
+		return;
+	}
+
+	if (mode == GL_POINTS) {
+		mat4 mvp;
+		mat4_multiply(&mvp, &ctx->projection_matrix,
+			      &ctx->modelview_matrix);
+		for (GLint i = 0; i < count; ++i) {
+			GLuint idx = type == GL_UNSIGNED_BYTE ?
+					     (GLuint)u8_indices[i] :
+					     (GLuint)u16_indices[i];
+			const GLfloat *vp =
+				(const GLfloat *)(vptr + (size_t)idx * vstride);
+			Vertex src = { 0 };
+			src.x = vp[0];
+			src.y = ctx->vertex_array.size > 1 ? vp[1] : 0.0f;
+			src.z = ctx->vertex_array.size > 2 ? vp[2] : 0.0f;
+			src.w = ctx->vertex_array.size > 3 ? vp[3] : 1.0f;
+			for (int k = 0; k < 3; ++k)
+				src.normal[k] = ctx->current_normal[k];
+			for (int k = 0; k < 4; ++k)
+				src.color[k] = ctx->current_color[k];
+			for (int k = 0; k < 4; ++k)
+				src.texcoord[k] = ctx->current_texcoord[0][k];
+			src.point_size = gl_state.point_size;
+			if (gl_state.point_size_array_pointer) {
+				const uint8_t *pptr =
+					(const uint8_t *)gl_state
+						.point_size_array_pointer;
+				if (gl_state.point_size_array_stride)
+					pptr += (size_t)idx *
+						gl_state.point_size_array_stride;
+				if (gl_state.point_size_array_type == GL_FLOAT)
+					src.point_size = *(const GLfloat *)pptr;
+			}
+			Vertex dst;
+			pipeline_transform_vertex(&dst, &src, &mvp, NULL);
+			pipeline_rasterize_point(&dst, src.point_size, fb);
+		}
+		PROFILE_END("glDrawElements");
+		return;
+	}
+
+	for (GLsizei i = 0; i + 2 < count; i += 3) {
+		VertexJob *job = MT_ALLOC(sizeof(VertexJob), STAGE_VERTEX);
+		if (!job) {
+			PROFILE_END("glDrawElements");
+			return;
+		}
+		for (int j = 0; j < 3; ++j) {
+			GLuint idx = type == GL_UNSIGNED_BYTE ?
+					     (GLuint)u8_indices[i + j] :
+					     (GLuint)u16_indices[i + j];
+			const GLfloat *vp =
+				(const GLfloat *)(vptr + (size_t)idx * vstride);
+			Vertex *dst = &job->in[j];
+			dst->x = vp[0];
+			dst->y = ctx->vertex_array.size > 1 ? vp[1] : 0.0f;
+			dst->z = ctx->vertex_array.size > 2 ? vp[2] : 0.0f;
+			dst->w = ctx->vertex_array.size > 3 ? vp[3] : 1.0f;
+			if (ctx->normal_array.enabled) {
+				const GLfloat *np =
+					(const GLfloat *)(nptr +
+							  (size_t)idx *
+								  nstride);
+				dst->normal[0] = np[0];
+				dst->normal[1] = np[1];
+				dst->normal[2] = np[2];
+			} else {
+				dst->normal[0] = ctx->current_normal[0];
+				dst->normal[1] = ctx->current_normal[1];
+				dst->normal[2] = ctx->current_normal[2];
+			}
+			if (ctx->color_array.enabled) {
+				if (ctx->color_array.type == GL_FLOAT) {
+					const GLfloat *cp =
+						(const GLfloat
+							 *)(cptr +
+							    (size_t)idx *
+								    cstride);
+					for (int k = 0;
+					     k < ctx->color_array.size; ++k)
+						dst->color[k] = cp[k];
+				} else {
+					const GLubyte *cp =
+						cptr + (size_t)idx * cstride;
+					for (int k = 0;
+					     k < ctx->color_array.size; ++k)
+						dst->color[k] = cp[k] / 255.0f;
+				}
+				if (ctx->color_array.size == 3)
+					dst->color[3] = 1.0f;
+			} else {
+				for (int k = 0; k < 4; ++k)
+					dst->color[k] = ctx->current_color[k];
+			}
+			if (ctx->texcoord_array.enabled) {
+				const GLfloat *tp =
+					(const GLfloat *)(tptr +
+							  (size_t)idx *
+								  tstride);
+				for (int k = 0; k < ctx->texcoord_array.size;
+				     ++k)
+					dst->texcoord[k] = tp[k];
+				for (int k = ctx->texcoord_array.size; k < 4;
+				     ++k)
+					dst->texcoord[k] = k == 3 ? 1.0f : 0.0f;
+			} else {
+				for (int k = 0; k < 4; ++k)
+					dst->texcoord[k] =
+						ctx->current_texcoord[0][k];
+			}
+		}
+		job->fb = fb;
+		command_buffer_record_task(process_vertex_job, job,
+					   STAGE_VERTEX);
 	}
 	PROFILE_END("glDrawElements");
 }


### PR DESCRIPTION
## Summary
- build vertex primitives directly in `glDrawElements`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_68505f3e39888325a3f7feb55e7f39a3