### PR TITLE
Validate texture unit enumeration

### DIFF
--- a/src/gl_api_texture.c
+++ b/src/gl_api_texture.c
@@ -9,6 +9,10 @@
 
 GL_API void GL_APIENTRY glActiveTexture(GLenum texture)
 {
+	if (texture < GL_TEXTURE0 || texture > GL_TEXTURE1) {
+		glSetError(GL_INVALID_ENUM);
+		return;
+	}
 	context_active_texture(texture);
 }
 


### PR DESCRIPTION
## Summary
- check for GL_TEXTURE0 and GL_TEXTURE1 in `glActiveTexture`
- return `GL_INVALID_ENUM` when texture unit is outside this range

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `ASAN_OPTIONS=halt_on_error=1 ./build_debug/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_685060e98c8c83258a7cf8e95484cae2