### PR TITLE
Apply viewport transform in pipeline

### DIFF
--- a/src/gl_api_draw.c
+++ b/src/gl_api_draw.c
@@ -8,6 +8,7 @@
 #include "matrix_utils.h"
 #include "gl_thread.h"
 #include "function_profile.h"
+#include <string.h>
 #include <GLES/gl.h>
 #include <stdatomic.h>
 
@@ -142,8 +143,10 @@ GL_API void GL_APIENTRY glDrawArrays(GLenum mode, GLint first, GLsizei count)
 					src.point_size = *(const GLfloat *)pptr;
 			}
 			Vertex dst;
-			pipeline_transform_vertex(&dst, &src, &mvp, NULL);
-			pipeline_rasterize_point(&dst, src.point_size, fb);
+			pipeline_transform_vertex(&dst, &src, &mvp, NULL,
+						  gl_state.viewport);
+			pipeline_rasterize_point(&dst, src.point_size,
+						 gl_state.viewport, fb);
 		}
 		return;
 	}
@@ -152,6 +155,7 @@ GL_API void GL_APIENTRY glDrawArrays(GLenum mode, GLint first, GLsizei count)
 		VertexJob *job = MT_ALLOC(sizeof(VertexJob), STAGE_VERTEX);
 		if (!job)
 			return;
+		memcpy(job->viewport, gl_state.viewport, sizeof(job->viewport));
 		for (int j = 0; j < 3; ++j) {
 			GLint idx = first + i + j;
 			const GLfloat *vp =
@@ -391,8 +395,10 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 					src.point_size = *(const GLfloat *)pptr;
 			}
 			Vertex dst;
-			pipeline_transform_vertex(&dst, &src, &mvp, NULL);
-			pipeline_rasterize_point(&dst, src.point_size, fb);
+			pipeline_transform_vertex(&dst, &src, &mvp, NULL,
+						  gl_state.viewport);
+			pipeline_rasterize_point(&dst, src.point_size,
+						 gl_state.viewport, fb);
 		}
 		PROFILE_END("glDrawElements");
 		return;
@@ -404,6 +410,7 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 			PROFILE_END("glDrawElements");
 			return;
 		}
+		memcpy(job->viewport, gl_state.viewport, sizeof(job->viewport));
 		for (int j = 0; j < 3; ++j) {
 			GLuint idx = type == GL_UNSIGNED_BYTE ?
 					     (GLuint)u8_indices[i + j] :

--- a/src/pipeline/gl_primitive.c
+++ b/src/pipeline/gl_primitive.c
@@ -4,6 +4,7 @@
 #define PIPELINE_USE_GLSTATE 0
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
+#include <string.h>
 
 void pipeline_assemble_triangle(Triangle *dst, const Vertex *v0,
 				const Vertex *v1, const Vertex *v2)
@@ -33,6 +34,7 @@ void process_primitive_job(void *task_data)
 	}
 	rjob->tri = tri;
 	rjob->fb = job->fb;
+	memcpy(rjob->viewport, job->viewport, sizeof(job->viewport));
 	MT_FREE(job, STAGE_PRIMITIVE);
 	thread_pool_submit(process_raster_job, rjob, STAGE_RASTER);
 }

--- a/src/pipeline/gl_primitive.h
+++ b/src/pipeline/gl_primitive.h
@@ -14,6 +14,7 @@ void pipeline_assemble_triangle(Triangle *dst, const Vertex *v0,
 typedef struct {
 	Vertex verts[3];
 	Framebuffer *fb;
+	GLint viewport[4];
 } PrimitiveJob;
 
 void process_primitive_job(void *task_data);

--- a/src/pipeline/gl_raster.h
+++ b/src/pipeline/gl_raster.h
@@ -8,8 +8,10 @@
 extern "C" {
 #endif
 
-void pipeline_rasterize_triangle(const Triangle *tri, Framebuffer *fb);
-void pipeline_rasterize_point(const Vertex *v, GLfloat size, Framebuffer *fb);
+void pipeline_rasterize_triangle(const Triangle *tri, const GLint viewport[4],
+				 Framebuffer *fb);
+void pipeline_rasterize_point(const Vertex *v, GLfloat size,
+			      const GLint viewport[4], Framebuffer *fb);
 
 #define TILE_SIZE 16
 
@@ -27,6 +29,7 @@ typedef struct {
 typedef struct {
 	Triangle tri;
 	Framebuffer *fb;
+	GLint viewport[4];
 } RasterJob;
 
 void process_raster_job(void *task_data);

--- a/src/pipeline/gl_vertex.h
+++ b/src/pipeline/gl_vertex.h
@@ -12,10 +12,11 @@ extern "C" {
 typedef struct {
 	Vertex in[3];
 	Framebuffer *fb;
+	GLint viewport[4];
 } VertexJob;
 
 void pipeline_transform_vertex(Vertex *dst, const Vertex *src, const mat4 *mvp,
-			       const mat4 *normal_mat);
+			       const mat4 *normal_mat, const GLint viewport[4]);
 void process_vertex_job(void *task_data);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- update vertex transform to produce window coordinates
- clamp rasterization to viewport bounds
- thread jobs carry viewport data through pipeline

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `timeout 5 ./build/bin/benchmark`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_6850690b2530832592d821d7c309d482