### PR TITLE
Implement tile locking for fragment writes

### DIFF
--- a/src/pipeline/gl_framebuffer.h
+++ b/src/pipeline/gl_framebuffer.h
@@ -6,6 +6,17 @@
 #include <stdalign.h>
 #include <assert.h>
 #include <stdatomic.h>
+#include "gl_thread.h"
+
+#define TILE_SIZE 16
+
+typedef struct {
+	uint32_t x0, y0;
+	uint32_t color[TILE_SIZE * TILE_SIZE];
+	float depth[TILE_SIZE * TILE_SIZE];
+	uint8_t stencil[TILE_SIZE * TILE_SIZE];
+	atomic_flag lock;
+} FramebufferTile;
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +28,13 @@ typedef struct Framebuffer {
 	_Atomic uint32_t *color_buffer;
 	_Atomic float *depth_buffer;
 	_Atomic uint8_t *stencil_buffer;
+	FramebufferTile *tiles;
+	uint32_t tiles_x;
+	uint32_t tiles_y;
 } Framebuffer;
+
+void framebuffer_enter_tile(FramebufferTile *tile);
+void framebuffer_leave_tile(void);
 
 static_assert(sizeof(uint32_t) == 4, "Framebuffer requires 32-bit colors");
 


### PR DESCRIPTION
## Summary
- add `FramebufferTile` with per-tile lock
- keep a thread-local tile pointer for fragment jobs
- update `framebuffer_set_pixel` to write into the active tile buffer
- flush tiles in `process_fragment_tile_job`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build/bin/benchmark --help` *(fails to capture output)*

------
https://chatgpt.com/codex/tasks/task_e_6850695da1b48325809270a226f1cbaf