### PR TITLE
Add env-based thread pool initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cmake --build build
 ./build/bin/benchmark
 ./build/bin/renderer_conformance
 ```
+Set `MICROGLES_THREADS` to specify the number of worker threads.
 
 To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required.
 
@@ -111,7 +112,7 @@ int main(void)
     /* Infrastructure */
     logger_init(NULL, LOG_LEVEL_INFO);
     memory_tracker_init();
-    thread_pool_init(4); /* 4 worker threads */
+    thread_pool_init_from_env(); /* uses MICROGLES_THREADS or 4 */
 #ifdef ENABLE_PROFILE
     thread_profile_start(); /* Optional: per-stage timings */
 #endif
@@ -147,6 +148,7 @@ int main(void)
 ```
 
 Compile with `-DENABLE_PROFILE` or run any program with `--profile` to record per-stage timings. Without the flag, tasks still execute but no profiling counters are recorded.
+Set `MICROGLES_THREADS` to override the default thread count (4).
 
 ## Profiling
 

--- a/benchmark/src/main.c
+++ b/benchmark/src/main.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to initialize Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init(4);
+	thread_pool_init_from_env();
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/benchmark/src/stress_main.c
+++ b/benchmark/src/stress_main.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to initialize Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init(4);
+	thread_pool_init_from_env();
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/conformance/src/tests_main.c
+++ b/conformance/src/tests_main.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to init Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init(4);
+	thread_pool_init_from_env();
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -271,6 +271,20 @@ void thread_pool_init(int num_threads)
 	}
 }
 
+int thread_pool_init_from_env(void)
+{
+	const char *var = getenv("MICROGLES_THREADS");
+	long val = 4;
+	if (var && *var) {
+		char *end;
+		long tmp = strtol(var, &end, 10);
+		if (*end == '\0' && tmp > 0 && tmp <= 64)
+			val = tmp;
+	}
+	thread_pool_init((int)val);
+	return (int)val;
+}
+
 void thread_pool_submit(task_function_t func, void *task_data,
 			stage_tag_t stage)
 {

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -26,6 +26,7 @@ typedef enum {
 typedef void (*task_function_t)(void *task_data);
 
 void thread_pool_init(int num_threads);
+int thread_pool_init_from_env(void);
 void thread_pool_submit(task_function_t func, void *task_data,
 			stage_tag_t stage);
 void thread_pool_wait(void);


### PR DESCRIPTION
## Summary
- add `thread_pool_init_from_env()` helper
- initialize thread pool from environment in benchmark and conformance programs
- document `MICROGLES_THREADS` usage in the README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `./build/bin/renderer_conformance`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `ASAN_OPTIONS=halt_on_error=1 ./build_debug/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_685092ec8e0083258b0af36a436a09c2