### PR TITLE
Add STEAL profiling stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ profiling is enabled (either by compiling with `-DENABLE_PROFILE` or passing
 `--profile` on the command line) each worker thread measures the cycle count
 spent in every pipeline stage while processing a command buffer. At shutdown
 `thread_profile_report()` prints a table showing task counts, average cycles per
-task and cache statistics for the vertex, primitive, raster, fragment and
-framebuffer stages. The data pinpoints bottlenecks—e.g. excessive fragment time
+task and cache statistics for the vertex, primitive, raster, fragment, framebuffer
+and steal stages. The data pinpoints bottlenecks—e.g. excessive fragment time
 may suggest better texture caching or smaller tile size—allowing refinement of
 math routines and thread counts.
 

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -75,8 +75,9 @@ static uint64_t get_cycles(void)
 #endif
 }
 
-static const char *stage_names[STAGE_COUNT] = { "Vertex", "Primitive", "Raster",
-						"Fragment", "Framebuffer" };
+static const char *stage_names[STAGE_COUNT] = { "Vertex",      "Primitive",
+						"Raster",      "Fragment",
+						"Framebuffer", "Steal" };
 
 static bool steal_task(int thread_id, task_t *out, bool profiling)
 {
@@ -122,7 +123,7 @@ static bool steal_task(int thread_id, task_t *out, bool profiling)
 		}
 	}
 	if (profiling)
-		g_thread_profile.stages[STAGE_VERTEX].steal_cycles +=
+		g_thread_profile.stages[STAGE_STEAL].steal_cycles +=
 			get_cycles() - start;
 	return false;
 }

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -20,6 +20,7 @@ typedef enum {
 	STAGE_RASTER,
 	STAGE_FRAGMENT,
 	STAGE_FRAMEBUFFER,
+	STAGE_STEAL,
 	STAGE_COUNT
 } stage_tag_t;
 


### PR DESCRIPTION
## Summary
- extend `stage_tag_t` with a new STEAL entry
- record failed steal cycles under the STEAL stage
- list the new stage name for reports
- document the extra stage in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark --profile` *(no output)*
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_685092e323208325b10741b1514dfe4f