### PR TITLE
Add microsecond conversion for profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,16 @@ microGLES includes a lightweight profiler integrated into the thread pool. When
 profiling is enabled (either by compiling with `-DENABLE_PROFILE` or passing
 `--profile` on the command line) each worker thread measures the cycle count
 spent in every pipeline stage while processing a command buffer. At shutdown
-`thread_profile_report()` prints a table showing task counts, average cycles per
-task and cache statistics for the vertex, primitive, raster, fragment, framebuffer
-and steal stages. The data pinpoints bottlenecks—e.g. excessive fragment time
-may suggest better texture caching or smaller tile size—allowing refinement of
-math routines and thread counts.
+`thread_profile_report()` prints a table showing task counts, average time per
+task (microseconds) and cache statistics for the vertex, primitive, raster,
+fragment, framebuffer and steal stages. The data pinpoints bottlenecks—e.g.
+excessive fragment time may suggest better texture caching or smaller tile
+size—allowing refinement of math routines and thread counts.
+
+The conversion from cycle counts to microseconds is platform dependent.
+Systems without a cycle counter treat the value as nanoseconds. When
+`__builtin_readcyclecounter` is available, the profiler calibrates CPU
+frequency on first use so reported times are approximations.
 
 ### Linking as a Static Library
 

--- a/src/function_profile.c
+++ b/src/function_profile.c
@@ -1,5 +1,6 @@
 #include "function_profile.h"
 #include "gl_logger.h"
+#include "gl_thread.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -52,9 +53,10 @@ void function_profile_report(void)
 	      compare_profile);
 	LOG_INFO("GL Function Profiling Results:");
 	for (int i = 0; i < g_profile_count; ++i) {
-		LOG_INFO("  %s: calls=%llu cycles=%llu",
+		LOG_INFO("  %s: calls=%llu time=%lluus",
 			 g_profiles[i].name ? g_profiles[i].name : "(null)",
 			 (unsigned long long)g_profiles[i].call_count,
-			 (unsigned long long)g_profiles[i].total_cycles);
+			 (unsigned long long)thread_cycles_to_us(
+				 g_profiles[i].total_cycles));
 	}
 }

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -42,6 +42,7 @@ void thread_profile_stop(void);
 void thread_profile_report(void);
 bool thread_profile_is_enabled(void);
 uint64_t thread_get_cycles(void);
+uint64_t thread_cycles_to_us(uint64_t cycles);
 
 /* texture cache helpers */
 texture_cache_t *thread_get_texture_cache(void);


### PR DESCRIPTION
## Summary
- add thread_cycles_to_us() to convert cycles to µs
- report times in microseconds in profiler logs
- show per-function time in microseconds
- document profiling precision in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `cmake --build build --target format`

------
https://chatgpt.com/codex/tasks/task_e_68509c736b3c8325a2547c3e835adf2e