### PR TITLE
Add depth and task metrics to profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ profiling is enabled (either by compiling with `-DENABLE_PROFILE` or passing
 `--profile` on the command line) each worker thread measures the cycle count
 spent in every pipeline stage while processing a command buffer. At shutdown
 `thread_profile_report()` prints a table showing task counts, average time per
-task (microseconds) and cache statistics for the vertex, primitive, raster,
-fragment, framebuffer and steal stages. The data pinpoints bottlenecks—e.g.
+task (microseconds), maximum queue depth, longest task time and cache statistics
+for the vertex, primitive, raster, fragment, framebuffer and steal stages. The
+data pinpoints bottlenecks—e.g.
 excessive fragment time may suggest better texture caching or smaller tile
 size—allowing refinement of math routines and thread counts.
 


### PR DESCRIPTION
## Summary
- track peak task queue depth and longest task time
- expose the new statistics in `thread_profile_report`
- document the metrics in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68509e5c9c348325bb5a9943d5fc4fc5