### PR TITLE
Improve thread pool setup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ int main(void)
     /* Infrastructure */
     logger_init(NULL, LOG_LEVEL_INFO);
     memory_tracker_init();
-    thread_pool_init_from_env(); /* uses MICROGLES_THREADS or 4 */
+    if (!thread_pool_init_from_env()) {
+        LOG_FATAL("Thread pool init failed");
+        return -1;
+    }
 #ifdef ENABLE_PROFILE
     thread_profile_start(); /* Optional: per-stage timings */
 #endif

--- a/benchmark/src/main.c
+++ b/benchmark/src/main.c
@@ -24,7 +24,10 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to initialize Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init_from_env();
+	if (!thread_pool_init_from_env()) {
+		LOG_FATAL("Failed to init thread pool");
+		return -1;
+	}
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/benchmark/src/stress_main.c
+++ b/benchmark/src/stress_main.c
@@ -27,7 +27,10 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to initialize Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init_from_env();
+	if (!thread_pool_init_from_env()) {
+		LOG_FATAL("Failed to init thread pool");
+		return -1;
+	}
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/conformance/src/tests_main.c
+++ b/conformance/src/tests_main.c
@@ -46,7 +46,10 @@ int main(int argc, char **argv)
 		LOG_FATAL("Failed to init Memory Tracker.");
 		return -1;
 	}
-	thread_pool_init_from_env();
+	if (!thread_pool_init_from_env()) {
+		LOG_FATAL("Failed to init thread pool");
+		return -1;
+	}
 	command_buffer_init();
 	if (profile)
 		thread_profile_start();

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -26,7 +26,7 @@ typedef enum {
 
 typedef void (*task_function_t)(void *task_data);
 
-void thread_pool_init(int num_threads);
+int thread_pool_init(int num_threads);
 int thread_pool_init_from_env(void);
 void thread_pool_submit(task_function_t func, void *task_data,
 			stage_tag_t stage);


### PR DESCRIPTION
## Summary
- detect memory allocation failures in `thread_pool_init`
- check `thrd_create` results and clean up on failure
- return thread count from `thread_pool_init`/`_from_env`
- propagate errors in benchmarks and conformance runner
- document new usage in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/benchmark` *(failed: no output)*
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68509e4338388325890af0bcadb9d1f5