### PR TITLE
Implement job object pools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCE_FILES
     src/pipeline/gl_raster.c
     src/pipeline/gl_fragment.c
     src/matrix_utils.c
+    src/pool.c
     src/gl_memory_tracker.c
     src/gl_logger.c
 )
@@ -66,6 +67,7 @@ set(HEADER_FILES
     src/pipeline/gl_primitive.h
     src/pipeline/gl_raster.h
     src/pipeline/gl_fragment.h
+    src/pool.h
     src/gl_memory_tracker.h
     src/gl_logger.h
     src/gl_context.h

--- a/src/gl_api_draw.c
+++ b/src/gl_api_draw.c
@@ -3,6 +3,7 @@
 #include "gl_memory_tracker.h"
 #include "gl_init.h"
 #include "command_buffer.h"
+#include "pool.h"
 #include "pipeline/gl_vertex.h"
 #include "pipeline/gl_raster.h"
 #include "matrix_utils.h"
@@ -152,7 +153,7 @@ GL_API void GL_APIENTRY glDrawArrays(GLenum mode, GLint first, GLsizei count)
 	}
 
 	for (GLint i = 0; i + 2 < count; i += 3) {
-		VertexJob *job = MT_ALLOC(sizeof(VertexJob), STAGE_VERTEX);
+		VertexJob *job = vertex_job_acquire();
 		if (!job)
 			return;
 		memcpy(job->viewport, gl_state.viewport, sizeof(job->viewport));
@@ -405,7 +406,7 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 	}
 
 	for (GLsizei i = 0; i + 2 < count; i += 3) {
-		VertexJob *job = MT_ALLOC(sizeof(VertexJob), STAGE_VERTEX);
+		VertexJob *job = vertex_job_acquire();
 		if (!job) {
 			PROFILE_END("glDrawElements");
 			return;

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -1,5 +1,6 @@
 #include "gl_thread.h"
 #include "gl_logger.h"
+#include "pool.h"
 #include "function_profile.h"
 #include <stdatomic.h>
 #include <stdint.h>
@@ -270,6 +271,7 @@ void thread_pool_init(int num_threads)
 	g_texture_caches = calloc(g_num_threads, sizeof(texture_cache_t));
 	mtx_init(&g_wakeup_mutex, mtx_plain);
 	cnd_init(&g_wakeup);
+	job_pools_init();
 	for (int i = 0; i < g_num_threads; ++i)
 		texture_cache_init(&g_texture_caches[i]);
 	atomic_init(&g_global_head, 0);
@@ -392,6 +394,7 @@ void thread_pool_shutdown(void)
 	for (int i = 0; i < g_num_threads; ++i)
 		thrd_join(g_worker_threads[i], NULL);
 	thread_profile_report();
+	job_pools_destroy();
 	free(g_worker_threads);
 	free(g_local_queues);
 	free(g_texture_caches);

--- a/src/pipeline/gl_fragment.c
+++ b/src/pipeline/gl_fragment.c
@@ -6,6 +6,7 @@
 #define PIPELINE_USE_GLSTATE 0
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
+#include "../pool.h"
 #include "../gl_types.h"
 #include "gl_framebuffer.h"
 #include "gl_raster.h"
@@ -360,5 +361,5 @@ void process_fragment_tile_job(void *task_data)
 		       &tile->stencil[row * TILE_SIZE], w * sizeof(uint8_t));
 	}
 	atomic_flag_clear(&tile->lock);
-	MT_FREE(job, STAGE_FRAGMENT);
+	tile_job_release(job);
 }

--- a/src/pipeline/gl_primitive.c
+++ b/src/pipeline/gl_primitive.c
@@ -1,6 +1,7 @@
 #include "gl_primitive.h"
 #include "gl_raster.h"
 #include "../gl_thread.h"
+#include "../pool.h"
 #define PIPELINE_USE_GLSTATE 0
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
@@ -27,7 +28,7 @@ void process_primitive_job(void *task_data)
 		MT_FREE(job, STAGE_PRIMITIVE);
 		return; // culled
 	}
-	RasterJob *rjob = MT_ALLOC(sizeof(RasterJob), STAGE_RASTER);
+	RasterJob *rjob = raster_job_acquire();
 	if (!rjob) {
 		MT_FREE(job, STAGE_PRIMITIVE);
 		return;

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -5,6 +5,7 @@
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
 #include "../gl_thread.h"
+#include "../pool.h"
 #include <string.h>
 #include <math.h>
 #include "../matrix_utils.h"
@@ -167,6 +168,6 @@ void process_vertex_job(void *task_data)
 	pjob->verts[2] = v2;
 	pjob->fb = job->fb;
 	memcpy(pjob->viewport, job->viewport, sizeof(job->viewport));
-	MT_FREE(job, STAGE_VERTEX);
+	vertex_job_release(job);
 	thread_pool_submit(process_primitive_job, pjob, STAGE_PRIMITIVE);
 }

--- a/src/pool.c
+++ b/src/pool.c
@@ -1,0 +1,127 @@
+#include "pool.h"
+#include "gl_memory_tracker.h"
+#include "pipeline/gl_vertex.h"
+#include "pipeline/gl_raster.h"
+#include <stdlib.h>
+
+struct PoolNode {
+	struct PoolNode *next_free;
+	struct PoolNode *next_all;
+};
+
+struct ObjectPool {
+	struct PoolNode *free_list;
+	struct PoolNode *all_nodes;
+	mtx_t mutex;
+	size_t obj_size;
+	unsigned capacity;
+	stage_tag_t stage;
+};
+
+/* global pools for common job types */
+static ObjectPool g_vertex_job_pool;
+static ObjectPool g_raster_job_pool;
+static ObjectPool g_tile_job_pool;
+#define JOB_POOL_CAPACITY 512
+
+void pool_init(ObjectPool *pool, size_t obj_size, unsigned capacity,
+	       stage_tag_t stage)
+{
+	*pool = (ObjectPool){ 0 };
+	pool->obj_size = obj_size;
+	pool->capacity = capacity;
+	pool->stage = stage;
+	mtx_init(&pool->mutex, mtx_plain);
+	for (unsigned i = 0; i < capacity; ++i) {
+		struct PoolNode *node =
+			MT_ALLOC(sizeof(struct PoolNode) + obj_size, stage);
+		if (!node)
+			break;
+		node->next_free = pool->free_list;
+		pool->free_list = node;
+		node->next_all = pool->all_nodes;
+		pool->all_nodes = node;
+	}
+}
+
+void *pool_acquire(ObjectPool *pool)
+{
+	mtx_lock(&pool->mutex);
+	struct PoolNode *node = pool->free_list;
+	if (node)
+		pool->free_list = node->next_free;
+	mtx_unlock(&pool->mutex);
+	if (!node)
+		return NULL;
+	return (void *)(node + 1);
+}
+
+void pool_release(ObjectPool *pool, void *obj)
+{
+	if (!obj)
+		return;
+	struct PoolNode *node = ((struct PoolNode *)obj) - 1;
+	mtx_lock(&pool->mutex);
+	node->next_free = pool->free_list;
+	pool->free_list = node;
+	mtx_unlock(&pool->mutex);
+}
+
+void pool_destroy(ObjectPool *pool)
+{
+	struct PoolNode *node = pool->all_nodes;
+	while (node) {
+		struct PoolNode *next = node->next_all;
+		MT_FREE(node, pool->stage);
+		node = next;
+	}
+	mtx_destroy(&pool->mutex);
+	*pool = (ObjectPool){ 0 };
+}
+
+void job_pools_init(void)
+{
+	pool_init(&g_vertex_job_pool, sizeof(VertexJob), JOB_POOL_CAPACITY,
+		  STAGE_VERTEX);
+	pool_init(&g_raster_job_pool, sizeof(RasterJob), JOB_POOL_CAPACITY,
+		  STAGE_RASTER);
+	pool_init(&g_tile_job_pool, sizeof(FragmentTileJob), JOB_POOL_CAPACITY,
+		  STAGE_FRAGMENT);
+}
+
+void job_pools_destroy(void)
+{
+	pool_destroy(&g_tile_job_pool);
+	pool_destroy(&g_raster_job_pool);
+	pool_destroy(&g_vertex_job_pool);
+}
+
+VertexJob *vertex_job_acquire(void)
+{
+	return (VertexJob *)pool_acquire(&g_vertex_job_pool);
+}
+
+void vertex_job_release(VertexJob *job)
+{
+	pool_release(&g_vertex_job_pool, job);
+}
+
+RasterJob *raster_job_acquire(void)
+{
+	return (RasterJob *)pool_acquire(&g_raster_job_pool);
+}
+
+void raster_job_release(RasterJob *job)
+{
+	pool_release(&g_raster_job_pool, job);
+}
+
+FragmentTileJob *tile_job_acquire(void)
+{
+	return (FragmentTileJob *)pool_acquire(&g_tile_job_pool);
+}
+
+void tile_job_release(FragmentTileJob *job)
+{
+	pool_release(&g_tile_job_pool, job);
+}

--- a/src/pool.h
+++ b/src/pool.h
@@ -1,0 +1,35 @@
+#ifndef POOL_H
+#define POOL_H
+#include <stddef.h>
+#include <threads.h>
+#include "gl_thread.h" /* stage_tag_t */
+#include "pipeline/gl_vertex.h"
+#include "pipeline/gl_raster.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ObjectPool ObjectPool;
+
+void pool_init(ObjectPool *pool, size_t obj_size, unsigned capacity,
+	       stage_tag_t stage);
+void *pool_acquire(ObjectPool *pool);
+void pool_release(ObjectPool *pool, void *obj);
+void pool_destroy(ObjectPool *pool);
+
+/* Job specific helpers */
+void job_pools_init(void);
+void job_pools_destroy(void);
+VertexJob *vertex_job_acquire(void);
+void vertex_job_release(VertexJob *job);
+RasterJob *raster_job_acquire(void);
+void raster_job_release(RasterJob *job);
+FragmentTileJob *tile_job_acquire(void);
+void tile_job_release(FragmentTileJob *job);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* POOL_H */


### PR DESCRIPTION
## Summary
- add a generic object pool with typed helpers
- reuse vertex, raster and tile jobs from pools
- init/destroy pools with thread pool

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68509e687bb08325b7f66b07057097c3