### PR TITLE
Use online CPU count for default threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ cmake --build build
 ./build/bin/benchmark
 ./build/bin/renderer_conformance
 ```
-Set `MICROGLES_THREADS` to specify the number of worker threads.
+Set `MICROGLES_THREADS` to specify the number of worker threads (defaults to the
+number of online CPUs).
 
 To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required.
 
@@ -112,7 +113,8 @@ int main(void)
     /* Infrastructure */
     logger_init(NULL, LOG_LEVEL_INFO);
     memory_tracker_init();
-    thread_pool_init_from_env(); /* uses MICROGLES_THREADS or 4 */
+    thread_pool_init_from_env(); /* uses MICROGLES_THREADS or the
+                                   number of online CPUs */
 #ifdef ENABLE_PROFILE
     thread_profile_start(); /* Optional: per-stage timings */
 #endif
@@ -148,7 +150,8 @@ int main(void)
 ```
 
 Compile with `-DENABLE_PROFILE` or run any program with `--profile` to record per-stage timings. Without the flag, tasks still execute but no profiling counters are recorded.
-Set `MICROGLES_THREADS` to override the default thread count (4).
+Set `MICROGLES_THREADS` to override the default thread count (number of online
+CPUs).
 
 ## Profiling
 

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -7,6 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 #include "texture_cache.h"
 
 #define MAX_TASKS 256
@@ -288,13 +293,26 @@ void thread_pool_init(int num_threads)
 int thread_pool_init_from_env(void)
 {
 	const char *var = getenv("MICROGLES_THREADS");
-	long val = 4;
+	long val = -1;
 	if (var && *var) {
 		char *end;
 		long tmp = strtol(var, &end, 10);
 		if (*end == '\0' && tmp > 0 && tmp <= 64)
 			val = tmp;
 	}
+	if (val <= 0) {
+#ifdef _WIN32
+		SYSTEM_INFO info;
+		GetSystemInfo(&info);
+		val = info.dwNumberOfProcessors;
+#elif defined(_SC_NPROCESSORS_ONLN)
+		val = sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+	}
+	if (val <= 0)
+		val = 1;
+	if (val > 64)
+		val = 64;
 	thread_pool_init((int)val);
 	return (int)val;
 }


### PR DESCRIPTION
## Summary
- detect number of CPUs in `thread_pool_init_from_env`
- cap to 64 and fall back to 1
- document automatic CPU count in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_68509e733f688325b2b5cb5ff6e3239a