### PR TITLE
Fix framebuffer destruction race

### DIFF
--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -83,6 +83,10 @@ void framebuffer_destroy(Framebuffer *fb)
 {
 	if (!fb)
 		return;
+	if (thread_pool_active()) {
+		command_buffer_flush();
+		thread_pool_wait();
+	}
 	size_t pixels = (size_t)fb->width * fb->height;
 	tracked_free((void *)fb->color_buffer,
 		     pixels * sizeof(_Atomic uint32_t));


### PR DESCRIPTION
## Summary
- flush and wait for worker tasks in `framebuffer_destroy`

## Testing
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `timeout 20 ./build/bin/benchmark` *(no output)*
- `timeout 30 ./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6850a35f1af483258e9c2a8812bc104d