### PR TITLE
Rename milestone1 benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,10 @@ if(NOT GLESv1_CM_LIBRARY OR NOT EGL_LIBRARY)
     set(EGL_LIBRARY "")
 endif()
 
-# Find pthread
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+# Optional POSIX thread library
+if(NOT WIN32)
+    list(APPEND EXTRA_LIBS pthread)
+endif()
 find_package(X11)
 if(X11_FOUND)
     target_compile_definitions(renderer_lib PUBLIC HAVE_X11)
@@ -126,9 +127,8 @@ target_link_libraries(renderer PRIVATE
     renderer_lib
     ${GLESv1_CM_LIBRARY}
     ${EGL_LIBRARY}
-    Threads::Threads
-    m # Math library
     ${EXTRA_LIBS}
+    m # Math library
 )
 
 # Set output directories

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Each stage increments its own profiling counters (`thread_profile_report()`).
 - Keep each `gl_api_*.c` focused on a single spec chapter.
 - Prefer `MT_ALLOC/MT_FREE` and `thread_pool_submit()` over raw `malloc/thrd_create`.
 - Document non-obvious algorithms (e.g., atomic depth CAS loop) inline.
+- See [`docs/PORTABILITY.md`](docs/PORTABILITY.md) for cross-platform guidelines.
 
 Pull requests that break conformance or style are rejected automatically.
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BENCH_SOURCES
     src/spinning_cubes.c
     src/multitexture_demo.c
     src/alpha_blend_demo.c
-    src/miletostone1.c
+    src/milestone1.c
     src/milestone2.c
     src/texture_stream.c
     src/toggle_blend.c
@@ -33,7 +33,7 @@ target_include_directories(stress_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(stress_test PRIVATE renderer_lib Threads::Threads m)
+target_link_libraries(stress_test PRIVATE renderer_lib pthread m)
 
 set_target_properties(stress_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
@@ -47,7 +47,7 @@ set_target_properties(stress_test PROPERTIES
  )
 
 # Link with renderer library
- target_link_libraries(benchmark PRIVATE renderer_lib Threads::Threads m)
+ target_link_libraries(benchmark PRIVATE renderer_lib pthread m)
 
 set_target_properties(benchmark PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin

--- a/benchmark/src/benchmark.h
+++ b/benchmark/src/benchmark.h
@@ -31,7 +31,7 @@ void run_spinning_gears(Framebuffer *fb, BenchmarkResult *result);
 void run_spinning_cubes(Framebuffer *fb, BenchmarkResult *result);
 void run_multitexture_demo(Framebuffer *fb, BenchmarkResult *result);
 void run_alpha_blend_demo(Framebuffer *fb, BenchmarkResult *result);
-void run_miletostone1(Framebuffer *fb, BenchmarkResult *result);
+void run_milestone1(Framebuffer *fb, BenchmarkResult *result);
 void run_milestone2(Framebuffer *fb, BenchmarkResult *result);
 void run_texture_stream(Framebuffer *fb, BenchmarkResult *result);
 void run_toggle_blend(Framebuffer *fb, BenchmarkResult *result);

--- a/benchmark/src/main.c
+++ b/benchmark/src/main.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 #ifdef DEBUG
 	assert(glGetError() == GL_NO_ERROR);
 #endif
-	run_miletostone1(fb, &result);
+	run_milestone1(fb, &result);
 #ifdef DEBUG
 	assert(glGetError() == GL_NO_ERROR);
 #endif

--- a/benchmark/src/milestone1.c
+++ b/benchmark/src/milestone1.c
@@ -5,7 +5,7 @@
 #include "gl_context.h"
 #include <string.h>
 
-void run_miletostone1(Framebuffer *fb, BenchmarkResult *result)
+void run_milestone1(Framebuffer *fb, BenchmarkResult *result)
 {
 	GLfloat verts[] = { -0.5f, -0.5f, 0.0f, 0.5f,  -0.5f, 0.0f,
 			    0.5f,  0.5f,  0.0f, -0.5f, -0.5f, 0.0f,
@@ -40,6 +40,7 @@ void run_miletostone1(Framebuffer *fb, BenchmarkResult *result)
 	thread_pool_wait();
 
 	glEnable(GL_LIGHTING);
+	glEnable(GL_LIGHT0);
 	glLightfv(GL_LIGHT0, GL_DIFFUSE, (GLfloat[]){ 1.f, 1.f, 1.f, 1.f });
 	glEnable(GL_FOG);
 	glFogf(GL_FOG_MODE, GL_LINEAR);
@@ -63,7 +64,16 @@ void run_miletostone1(Framebuffer *fb, BenchmarkResult *result)
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 	glDeleteTextures(2, tex);
 
+	/* Reset feature state for later benchmarks */
+	glDisable(GL_FOG);
+	glDisable(GL_BLEND);
+	glDisable(GL_LIGHTING);
+	glDisable(GL_TEXTURE_2D);
+
 	compute_result(start, end, result);
-	LOG_INFO("miletostone1: %.2f FPS, %.2f ms/frame", result->fps,
+	GLenum err = glGetError();
+	if (err != GL_NO_ERROR)
+		LOG_ERROR("milestone1 GL error 0x%X", err);
+	LOG_INFO("milestone1: %.2f FPS, %.2f ms/frame", result->fps,
 		 result->cpu_time_ms);
 }

--- a/conformance/CMakeLists.txt
+++ b/conformance/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(renderer_conformance ${CONFORMANCE_SOURCES})
  )
 
 # Link with renderer library
- target_link_libraries(renderer_conformance PRIVATE renderer_lib Threads::Threads m)
+ target_link_libraries(renderer_conformance PRIVATE renderer_lib pthread m)
 
 set_target_properties(renderer_conformance PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,0 +1,25 @@
+# Portability Guidelines
+
+microGLES aims to build on any platform with a C11 toolchain. The core sources
+rely only on standard headers:
+
+```c
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdalign.h>
+```
+
+For threading, include `portable/c11threads.h`. When the compiler provides the
+standard `<threads.h>` header, it will be used. Otherwise the header falls back
+to the compact `tinycthread` implementation so no additional dependencies are
+required.
+
+Other platform specific functions are isolated in `src/portable/` so new ports
+only need to adjust that directory. Avoid OS APIs elsewhere and prefer the
+helpers provided by the project.
+
+Use CMake to generate project files for the target platform and enable the
+standard build flags found in `README.md`.

--- a/src/portable/c11threads.h
+++ b/src/portable/c11threads.h
@@ -3,8 +3,7 @@
 
 #if defined(__STDC_NO_THREADS__)
 #include "tinycthread.h"
-#else
-#if defined(__has_include)
+#elif defined(__has_include)
 #if __has_include(<threads.h>)
 #include <threads.h>
 #else
@@ -12,7 +11,6 @@
 #endif
 #else
 #include <threads.h>
-#endif
 #endif
 
 #endif /* C11THREADS_H */


### PR DESCRIPTION
## Summary
- rename misspelled `miletostone1.c`
- update benchmark header and main
- adjust CMake to build the corrected source
- fix milestone1 lighting to avoid GL errors
- add portability guidelines and link from README
- always use tinycthread (remove `<threads.h>` and `find_package(Threads)`)
- restore fallback to `<threads.h>` when available
- reset GL state in milestone1 and report any GL error

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build_debug/bin/renderer_conformance` *(fails: stack-buffer-overflow)*
- `./build/bin/benchmark` *(fails: runs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68518f7b4b6c8325bb3a8267a6180a89