### PR TITLE
Align CMake minimum version with README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version required
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 # Project name and version
 project(OpenGLES_Renderer VERSION 1.0 LANGUAGES C)


### PR DESCRIPTION
## Summary
- bump minimum CMake requirement to 3.20

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/benchmark 2>/tmp/benchmark.log`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6857b77a0e388325959d7f295b7aad9c