### PR TITLE
Fix async framebuffer clear race

### DIFF
--- a/conformance/src/tests/fbo.c
+++ b/conformance/src/tests/fbo.c
@@ -41,9 +41,21 @@ int test_framebuffer_module(void)
 	return ok;
 }
 
+int test_async_clear_destroy(void)
+{
+	Framebuffer *fb = framebuffer_create(8, 8);
+	if (!fb)
+		return 0;
+	framebuffer_clear_async(fb, 0x00000000u, 1.0f, 0);
+	framebuffer_destroy(fb);
+	thread_pool_wait();
+	return 1;
+}
+
 static const struct Test tests[] = {
 	{ "framebuffer_complete", test_framebuffer_complete },
 	{ "framebuffer_module", test_framebuffer_module },
+	{ "async_clear_destroy", test_async_clear_destroy },
 };
 
 const struct Test *get_fbo_tests(size_t *count)

--- a/src/pipeline/gl_framebuffer.h
+++ b/src/pipeline/gl_framebuffer.h
@@ -25,6 +25,7 @@ extern "C" {
 typedef struct Framebuffer {
 	uint32_t width;
 	uint32_t height;
+	_Atomic int ref_count;
 	_Atomic uint32_t *color_buffer;
 	_Atomic float *depth_buffer;
 	_Atomic uint8_t *stencil_buffer;
@@ -40,6 +41,8 @@ static_assert(sizeof(uint32_t) == 4, "Framebuffer requires 32-bit colors");
 
 Framebuffer *framebuffer_create(uint32_t width, uint32_t height);
 void framebuffer_destroy(Framebuffer *fb);
+void framebuffer_retain(Framebuffer *fb);
+void framebuffer_release(Framebuffer *fb);
 void framebuffer_clear(Framebuffer *fb, uint32_t clear_color, float clear_depth,
 		       uint8_t clear_stencil);
 void framebuffer_set_pixel(Framebuffer *fb, uint32_t x, uint32_t y,


### PR DESCRIPTION
## Summary
- add reference counting to Framebuffer objects
- retain/release framebuffer around async clear tasks
- add regression test for destroying framebuffer after async clear

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `./build/bin/renderer_conformance`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build_debug/bin/renderer_conformance` *(fails: stack-buffer-overflow in glGetFixedv)*

------
https://chatgpt.com/codex/tasks/task_e_6857b756fe84832580b047cc3473fe3e