### PR TITLE
Remove duplicate GL error helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCE_FILES
     src/gl_api_buffer.c
     src/gl_state.c
     src/gl_utils.c
+    src/gl_errors.c
     src/extensions/gl_ext_common.c
     src/extensions/gl_ext_OES_draw_texture.c
     src/extensions/gl_ext_OES_matrix_get.c

--- a/src/extensions/gl_ext_OES_blend_eq_sep.c
+++ b/src/extensions/gl_ext_OES_blend_eq_sep.c
@@ -1,4 +1,5 @@
 #include "gl_ext_common.h"
+#include "gl_errors.h"
 #include "../gl_state.h"
 #include "../gl_utils.h"
 

--- a/src/extensions/gl_ext_OES_draw_texture.c
+++ b/src/extensions/gl_ext_OES_draw_texture.c
@@ -1,3 +1,4 @@
+#include "gl_errors.h"
 #include "../gl_utils.h"
 #include "../gl_logger.h"
 #include "gl_ext_common.h"

--- a/src/extensions/gl_ext_OES_egl_image.c
+++ b/src/extensions/gl_ext_OES_egl_image.c
@@ -1,3 +1,4 @@
+#include "gl_errors.h"
 #include "gl_ext_common.h"
 #include "../gl_logger.h"
 #include "../gl_utils.h"

--- a/src/extensions/gl_ext_OES_framebuffer_object.c
+++ b/src/extensions/gl_ext_OES_framebuffer_object.c
@@ -3,6 +3,7 @@
 #include "gl_api_fbo.h"
 #include "gl_state.h"
 #include "gl_types.h"
+#include "gl_errors.h"
 #include "gl_utils.h"
 #include "gl_context.h"
 #include "gl_ext_common.h"

--- a/src/extensions/gl_ext_OES_point_size_array.c
+++ b/src/extensions/gl_ext_OES_point_size_array.c
@@ -1,3 +1,4 @@
+#include "gl_errors.h"
 #include "gl_ext_common.h"
 #include "../gl_utils.h"
 #include "../gl_logger.h"

--- a/src/gl_api_draw.c
+++ b/src/gl_api_draw.c
@@ -2,6 +2,7 @@
 #include "gl_context.h"
 #include "gl_memory_tracker.h"
 #include "gl_init.h"
+#include "gl_errors.h"
 #include "command_buffer.h"
 #include "pool.h"
 #include "pipeline/gl_vertex.h"

--- a/src/gl_api_misc.c
+++ b/src/gl_api_misc.c
@@ -448,11 +448,6 @@ GL_API void GL_APIENTRY glFlush(void)
 	command_buffer_flush();
 }
 
-GLenum glGetError(void)
-{
-	return glGetErrorAndClear();
-}
-
 GL_API const GLubyte *GL_APIENTRY glGetString(GLenum name)
 {
 	switch (name) {

--- a/src/gl_init.c
+++ b/src/gl_init.c
@@ -1,6 +1,7 @@
 #include "gl_init.h"
 #include "gl_logger.h"
 #include "gl_context.h"
+#include "gl_errors.h"
 #include "matrix_utils.h"
 #include "pipeline/gl_framebuffer.h"
 #include <GLES/gl.h>

--- a/src/gl_utils.c
+++ b/src/gl_utils.c
@@ -1,6 +1,7 @@
 /* gl_utils.c */
 
 #include "gl_utils.h"
+#include "gl_errors.h"
 #include "gl_logger.h" // For logging
 #include "gl_memory_tracker.h" // For MT_ALLOC and MT_FREE
 
@@ -26,30 +27,6 @@ void tracked_free(void *ptr, size_t size)
 		MT_FREE(ptr, STAGE_FRAMEBUFFER);
 		LOG_DEBUG("tracked_free: Freed %zu bytes at %p.", size, ptr);
 	}
-}
-
-/* Global variable to store the current OpenGL error */
-static GLenum current_error = GL_NO_ERROR;
-
-/* Function to set the current OpenGL error */
-void glSetError(GLenum error_code)
-{
-	if (current_error == GL_NO_ERROR) {
-		current_error = error_code;
-		LOG_DEBUG("glSetError: Set error to 0x%X.", error_code);
-	} else {
-		LOG_DEBUG(
-			"glSetError: Error already set to 0x%X. Ignoring new error 0x%X.",
-			current_error, error_code);
-	}
-}
-
-/* Function to retrieve and clear the current OpenGL error */
-GLenum glGetErrorAndClear(void)
-{
-	GLenum error = current_error;
-	current_error = GL_NO_ERROR;
-	return error;
 }
 
 /* Utility function to validate framebuffer completeness */

--- a/src/gl_utils.h
+++ b/src/gl_utils.h
@@ -4,7 +4,7 @@
 #define GL_UTILS_H
 /**
  * @file gl_utils.h
- * @brief Utility routines and error helpers.
+ * @brief Utility routines.
  */
 
 #include <GLES/gl.h> /* OpenGL ES 1.1 */
@@ -18,12 +18,6 @@ extern "C" {
 /* Memory tracking functions */
 void *tracked_malloc(size_t size);
 void tracked_free(void *ptr, size_t size);
-
-/* Error handling function */
-void glSetError(GLenum error_code);
-
-/* Function to retrieve and clear error */
-GLenum glGetErrorAndClear(void);
 
 #define FIXED_TO_FLOAT(x) ((GLfloat)(x) / 65536.0f)
 #define FLOAT_TO_FIXED(x) ((GLfixed)((x) * 65536.0f))


### PR DESCRIPTION
## Summary
- deduplicate glSetError & glGetError helpers
- include `gl_errors.h` where needed
- build with `gl_errors.c`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark & sleep 5; kill $!; wait $! 2>/dev/null`
- `./build/bin/renderer_conformance > /tmp/conformance.log && tail -n 20 /tmp/conformance.log`

------
https://chatgpt.com/codex/tasks/task_e_6857b76dcb908325bf5a558293a0b704