### PR TITLE
Update benchmark docs with real results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -6,20 +6,21 @@ frames-per-second (FPS) results observed on the reference machine.  Your
 numbers may vary depending on hardware and compiler options.
 
 Test system: Ubuntu 24.04, Intel Xeon Platinum 8370C (5 cores), 10 GiB RAM.
+Built with GCC 13.3 using `-std=gnu11 -O3 -ftree-vectorize`.
 
 | Benchmark Scene            | FPS |
 |----------------------------|-----|
-| Triangle Strip (100)       | 174825 FPS |
-| Triangle Strip (1000)      | 19853 FPS |
-| Triangle Strip (10000)     | 2158 FPS |
-| Textured Quad              | 578035 FPS |
-| Lit Cube (lighting on)     | 326797 FPS |
-| Lit Cube (lighting off)    | 473934 FPS |
+| Triangle Strip (100)       | 179211 FPS |
+| Triangle Strip (1000)      | 54289 FPS |
+| Triangle Strip (10000)     | 6306 FPS |
+| Textured Quad              | 359712 FPS |
+| Lit Cube (lighting on)     | 336700 FPS |
+| Lit Cube (lighting off)    | 288184 FPS |
 | FBO operations             | 100000000 FPS |
-| Pipeline Test              | 100000000 FPS |
-| Spinning Gears             | 123609 FPS |
-| Spinning Cubes             | 75233 MP/s |
-| Multitexture Demo          | 2028 MP/s |
-| Alpha Blend Demo           | 33333333 FPS |
+| Pipeline Test              | 33333333 FPS |
+| Spinning Gears             | 177620 FPS |
+| Spinning Cubes             | 57264 MP/s |
+| Multitexture Demo          | 1101 MP/s |
+| Alpha Blend Demo           | 25000000 FPS |
 | Fill Rate Suite            | N/A |
 | Stress Test (1M cubes)     | 47 FPS |

--- a/BENCHMARK_LOGS.md
+++ b/BENCHMARK_LOGS.md
@@ -1,14 +1,14 @@
 Example benchmark log output:
 
 ```
-[2025-06-11 00:29:48] [INFO] Memory tracker initialized
-[2025-06-11 00:29:48] [INFO] Initialized renderer with framebuffer 256x256
-[2025-06-11 00:29:48] [INFO] Triangle Strip 100: 260416.67 FPS, 0.00 ms/frame
-[2025-06-11 00:29:48] [INFO] Triangle Strip 1000: 13810.25 FPS, 0.07 ms/frame
-[2025-06-11 00:29:48] [INFO] Triangle Strip 10000: 1519.60 FPS, 0.66 ms/frame
-[2025-06-11 00:29:48] [INFO] Textured Quad: 14285714.29 FPS, 0.00 ms/frame
-[2025-06-11 00:29:48] [INFO] Lit Cube (lighting on): 25000000.00 FPS, 0.00 ms/frame
-[2025-06-11 00:29:48] [INFO] Lit Cube (lighting off): 50000000.00 FPS, 0.00 ms/frame
-[2025-06-11 00:29:48] [INFO] glDeleteRenderbuffersOES: Deleted renderbuffer ID 1.
-[2025-06-11 00:29:48] [INFO] FBO Benchmark: inf FPS, 0.00 ms/frame
+[1750579791.248910] [INFO] Memory tracker initialized
+[1750579791.255445] [INFO] Initialized renderer with framebuffer 256x256
+[1750579791.255741] [INFO] Triangle Strip 100: 179211.47 FPS, 0.01 ms/frame
+[1750579791.256675] [INFO] Triangle Strip 1000: 54288.82 FPS, 0.02 ms/frame
+[1750579791.264676] [INFO] Triangle Strip 10000: 6305.97 FPS, 0.16 ms/frame
+[1750579791.265282] [INFO] Textured Quad: 359712.23 FPS, 0.00 ms/frame
+[1750579791.265434] [INFO] Lit Cube (lighting on): 336700.34 FPS, 0.00 ms/frame
+[1750579791.265609] [INFO] Lit Cube (lighting off): 288184.44 FPS, 0.00 ms/frame
+[1750579791.265620] [INFO] glDeleteRenderbuffersOES: Deleted renderbuffer ID 1.
+[1750579791.265621] [INFO] FBO Benchmark: 100000000.00 FPS, 0.00 ms/frame
 ```


### PR DESCRIPTION
## Summary
- rerun benchmark suite with release build
- update BENCHMARK.md and BENCHMARK_LOGS.md with actual numbers
- note hardware and compiler options used

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6857b7b6077883258495bb8e62fdef4e