### PR TITLE
Fix truncated checklist item in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,4 +58,4 @@ benchmark/                   perf demos
 3. Benchmarks show ≤ 5 % perf regression (or explain).
 4. `clang-format` shows no diff.
 5. Update `README.md` and `CONFORMANCE.md` if behaviour changes.
-6. Push / MR.
+6. Push changes and open a merge request.


### PR DESCRIPTION
## Summary
- clarify the last step in the commit checklist
- ensure AGENTS guide ends with a newline

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark` *(fails: no output)*
- `./build/bin/renderer_conformance --version`

------
https://chatgpt.com/codex/tasks/task_e_6857b7c4e6fc8325b554f232c2499af4