### PR TITLE
Introduce fixed-point helper functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCE_FILES
     src/extensions/gl_ext_OES_required_internalformat.c
     src/extensions/gl_ext_OES_blend_eq_sep.c
     src/extensions/gl_ext_OES_fixed_point.c
+    src/fixed_point.c
     src/gl_context.c
     src/gl_thread.c
     src/texture_cache.c
@@ -73,6 +74,7 @@ set(HEADER_FILES
     src/gl_api_vertex_array.h
     src/gl_state.h
     src/gl_utils.h
+    src/fixed_point.h
     src/matrix_utils.h
     src/gl_types.h
     src/pipeline/gl_framebuffer.h

--- a/src/extensions/gl_ext_OES_draw_texture.c
+++ b/src/extensions/gl_ext_OES_draw_texture.c
@@ -37,8 +37,8 @@ GL_API void GL_APIENTRY glDrawTexiOES(GLint x, GLint y, GLint z, GLint width,
 GL_API void GL_APIENTRY glDrawTexxOES(GLfixed x, GLfixed y, GLfixed z,
 				      GLfixed width, GLfixed height)
 {
-	draw_tex_rect(FIXED_TO_FLOAT(x), FIXED_TO_FLOAT(y), FIXED_TO_FLOAT(z),
-		      FIXED_TO_FLOAT(width), FIXED_TO_FLOAT(height));
+	draw_tex_rect(fixed_to_float(x), fixed_to_float(y), fixed_to_float(z),
+		      fixed_to_float(width), fixed_to_float(height));
 }
 GL_API void GL_APIENTRY glDrawTexsvOES(const GLshort *coords)
 {
@@ -66,9 +66,9 @@ GL_API void GL_APIENTRY glDrawTexxvOES(const GLfixed *coords)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	draw_tex_rect(FIXED_TO_FLOAT(coords[0]), FIXED_TO_FLOAT(coords[1]),
-		      FIXED_TO_FLOAT(coords[2]), FIXED_TO_FLOAT(coords[3]),
-		      FIXED_TO_FLOAT(coords[4]));
+	draw_tex_rect(fixed_to_float(coords[0]), fixed_to_float(coords[1]),
+		      fixed_to_float(coords[2]), fixed_to_float(coords[3]),
+		      fixed_to_float(coords[4]));
 }
 GL_API void GL_APIENTRY glDrawTexfOES(GLfloat x, GLfloat y, GLfloat z,
 				      GLfloat width, GLfloat height)

--- a/src/extensions/gl_ext_OES_fixed_point.c
+++ b/src/extensions/gl_ext_OES_fixed_point.c
@@ -44,10 +44,10 @@ GL_API void GL_APIENTRY glClipPlanexOES(GLenum plane, const GLfixed *equation)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat eq[4] = { FIXED_TO_FLOAT(equation[0]),
-			  FIXED_TO_FLOAT(equation[1]),
-			  FIXED_TO_FLOAT(equation[2]),
-			  FIXED_TO_FLOAT(equation[3]) };
+	GLfloat eq[4] = { fixed_to_float(equation[0]),
+			  fixed_to_float(equation[1]),
+			  fixed_to_float(equation[2]),
+			  fixed_to_float(equation[3]) };
 	glClipPlanef(plane, eq);
 }
 
@@ -64,7 +64,7 @@ GL_API void GL_APIENTRY glDepthRangexOES(GLfixed n, GLfixed f)
 
 GL_API void GL_APIENTRY glFogxOES(GLenum pname, GLfixed param)
 {
-	glFogf(pname, FIXED_TO_FLOAT(param));
+	glFogf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glFogxvOES(GLenum pname, const GLfixed *param)
@@ -74,10 +74,10 @@ GL_API void GL_APIENTRY glFogxvOES(GLenum pname, const GLfixed *param)
 		return;
 	}
 	GLfloat vals[4];
-	vals[0] = FIXED_TO_FLOAT(param[0]);
-	vals[1] = FIXED_TO_FLOAT(param[1]);
-	vals[2] = FIXED_TO_FLOAT(param[2]);
-	vals[3] = FIXED_TO_FLOAT(param[3]);
+	vals[0] = fixed_to_float(param[0]);
+	vals[1] = fixed_to_float(param[1]);
+	vals[2] = fixed_to_float(param[2]);
+	vals[3] = fixed_to_float(param[3]);
 	glFogfv(pname, vals);
 }
 
@@ -175,7 +175,7 @@ GL_API void GL_APIENTRY glGetTexParameterxvOES(GLenum target, GLenum pname,
 
 GL_API void GL_APIENTRY glLightModelxOES(GLenum pname, GLfixed param)
 {
-	glLightModelf(pname, FIXED_TO_FLOAT(param));
+	glLightModelf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glLightModelxvOES(GLenum pname, const GLfixed *param)
@@ -184,15 +184,15 @@ GL_API void GL_APIENTRY glLightModelxvOES(GLenum pname, const GLfixed *param)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(param[0]), FIXED_TO_FLOAT(param[1]),
-			    FIXED_TO_FLOAT(param[2]),
-			    FIXED_TO_FLOAT(param[3]) };
+	GLfloat vals[4] = { fixed_to_float(param[0]), fixed_to_float(param[1]),
+			    fixed_to_float(param[2]),
+			    fixed_to_float(param[3]) };
 	glLightModelfv(pname, vals);
 }
 
 GL_API void GL_APIENTRY glLightxOES(GLenum light, GLenum pname, GLfixed param)
 {
-	glLightf(light, pname, FIXED_TO_FLOAT(param));
+	glLightf(light, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glLightxvOES(GLenum light, GLenum pname,
@@ -203,16 +203,16 @@ GL_API void GL_APIENTRY glLightxvOES(GLenum light, GLenum pname,
 		return;
 	}
 	GLfloat vals[4];
-	vals[0] = FIXED_TO_FLOAT(params[0]);
-	vals[1] = FIXED_TO_FLOAT(params[1]);
-	vals[2] = FIXED_TO_FLOAT(params[2]);
-	vals[3] = FIXED_TO_FLOAT(params[3]);
+	vals[0] = fixed_to_float(params[0]);
+	vals[1] = fixed_to_float(params[1]);
+	vals[2] = fixed_to_float(params[2]);
+	vals[3] = fixed_to_float(params[3]);
 	glLightfv(light, pname, vals);
 }
 
 GL_API void GL_APIENTRY glLineWidthxOES(GLfixed width)
 {
-	glLineWidth(FIXED_TO_FLOAT(width));
+	glLineWidth(fixed_to_float(width));
 }
 
 GL_API void GL_APIENTRY glLoadMatrixxOES(const GLfixed *m)
@@ -223,13 +223,13 @@ GL_API void GL_APIENTRY glLoadMatrixxOES(const GLfixed *m)
 	}
 	GLfloat mf[16];
 	for (int i = 0; i < 16; ++i)
-		mf[i] = FIXED_TO_FLOAT(m[i]);
+		mf[i] = fixed_to_float(m[i]);
 	glLoadMatrixf(mf);
 }
 
 GL_API void GL_APIENTRY glMaterialxOES(GLenum face, GLenum pname, GLfixed param)
 {
-	glMaterialf(face, pname, FIXED_TO_FLOAT(param));
+	glMaterialf(face, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glMaterialxvOES(GLenum face, GLenum pname,
@@ -239,9 +239,9 @@ GL_API void GL_APIENTRY glMaterialxvOES(GLenum face, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(param[0]), FIXED_TO_FLOAT(param[1]),
-			    FIXED_TO_FLOAT(param[2]),
-			    FIXED_TO_FLOAT(param[3]) };
+	GLfloat vals[4] = { fixed_to_float(param[0]), fixed_to_float(param[1]),
+			    fixed_to_float(param[2]),
+			    fixed_to_float(param[3]) };
 	glMaterialfv(face, pname, vals);
 }
 
@@ -253,20 +253,20 @@ GL_API void GL_APIENTRY glMultMatrixxOES(const GLfixed *m)
 	}
 	GLfloat mf[16];
 	for (int i = 0; i < 16; ++i)
-		mf[i] = FIXED_TO_FLOAT(m[i]);
+		mf[i] = fixed_to_float(m[i]);
 	glMultMatrixf(mf);
 }
 
 GL_API void GL_APIENTRY glMultiTexCoord4xOES(GLenum texture, GLfixed s,
 					     GLfixed t, GLfixed r, GLfixed q)
 {
-	glMultiTexCoord4f(texture, FIXED_TO_FLOAT(s), FIXED_TO_FLOAT(t),
-			  FIXED_TO_FLOAT(r), FIXED_TO_FLOAT(q));
+	glMultiTexCoord4f(texture, fixed_to_float(s), fixed_to_float(t),
+			  fixed_to_float(r), fixed_to_float(q));
 }
 
 GL_API void GL_APIENTRY glNormal3xOES(GLfixed nx, GLfixed ny, GLfixed nz)
 {
-	glNormal3f(FIXED_TO_FLOAT(nx), FIXED_TO_FLOAT(ny), FIXED_TO_FLOAT(nz));
+	glNormal3f(fixed_to_float(nx), fixed_to_float(ny), fixed_to_float(nz));
 }
 
 GL_API void GL_APIENTRY glOrthoxOES(GLfixed l, GLfixed r, GLfixed b, GLfixed t,
@@ -283,7 +283,7 @@ GL_API void GL_APIENTRY glRotatexOES(GLfixed angle, GLfixed x, GLfixed y,
 
 GL_API void GL_APIENTRY glSampleCoveragexOES(GLclampx value, GLboolean invert)
 {
-	glSampleCoverage(FIXED_TO_FLOAT(value), invert);
+	glSampleCoverage(fixed_to_float(value), invert);
 }
 
 GL_API void GL_APIENTRY glScalexOES(GLfixed x, GLfixed y, GLfixed z)
@@ -388,7 +388,7 @@ GL_API void GL_APIENTRY glTexGenxOES(GLenum coord, GLenum pname, GLfixed param)
 		glSetError(GL_INVALID_ENUM);
 		return;
 	}
-	glTexGenfOES(coord, pname, FIXED_TO_FLOAT(param));
+	glTexGenfOES(coord, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glTexGenxvOES(GLenum coord, GLenum pname,
@@ -398,9 +398,9 @@ GL_API void GL_APIENTRY glTexGenxvOES(GLenum coord, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat fp[4] = { FIXED_TO_FLOAT(params[0]), FIXED_TO_FLOAT(params[1]),
-			  FIXED_TO_FLOAT(params[2]),
-			  FIXED_TO_FLOAT(params[3]) };
+	GLfloat fp[4] = { fixed_to_float(params[0]), fixed_to_float(params[1]),
+			  fixed_to_float(params[2]),
+			  fixed_to_float(params[3]) };
 	glTexGenfvOES(coord, pname, fp);
 }
 

--- a/src/extensions/gl_extensions.c
+++ b/src/extensions/gl_extensions.c
@@ -44,7 +44,6 @@ GL_API void GL_APIENTRY glTexGenfvOES(GLenum coord, GLenum pname,
 }
 #endif
 #define MAX_PALETTE_MATRICES 32
-#define FIXED_TO_FLOAT(x) ((GLfloat)(x) / 65536.0f)
 
 static BufferObject *find_buffer(GLuint id)
 {
@@ -112,8 +111,8 @@ GL_API void GL_APIENTRY glDrawTexiOES(GLint x, GLint y, GLint z, GLint width,
 GL_API void GL_APIENTRY glDrawTexxOES(GLfixed x, GLfixed y, GLfixed z,
 				      GLfixed width, GLfixed height)
 {
-	draw_tex_rect(FIXED_TO_FLOAT(x), FIXED_TO_FLOAT(y), FIXED_TO_FLOAT(z),
-		      FIXED_TO_FLOAT(width), FIXED_TO_FLOAT(height));
+	draw_tex_rect(fixed_to_float(x), fixed_to_float(y), fixed_to_float(z),
+		      fixed_to_float(width), fixed_to_float(height));
 }
 
 GL_API void GL_APIENTRY glDrawTexsvOES(const GLshort *coords)
@@ -144,9 +143,9 @@ GL_API void GL_APIENTRY glDrawTexxvOES(const GLfixed *coords)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	draw_tex_rect(FIXED_TO_FLOAT(coords[0]), FIXED_TO_FLOAT(coords[1]),
-		      FIXED_TO_FLOAT(coords[2]), FIXED_TO_FLOAT(coords[3]),
-		      FIXED_TO_FLOAT(coords[4]));
+	draw_tex_rect(fixed_to_float(coords[0]), fixed_to_float(coords[1]),
+		      fixed_to_float(coords[2]), fixed_to_float(coords[3]),
+		      fixed_to_float(coords[4]));
 }
 
 GL_API void GL_APIENTRY glDrawTexfOES(GLfloat x, GLfloat y, GLfloat z,
@@ -445,8 +444,8 @@ GL_API void GL_APIENTRY glClipPlanexIMG(GLenum p, const GLfixed *eqn)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat eq[4] = { FIXED_TO_FLOAT(eqn[0]), FIXED_TO_FLOAT(eqn[1]),
-			  FIXED_TO_FLOAT(eqn[2]), FIXED_TO_FLOAT(eqn[3]) };
+	GLfloat eq[4] = { fixed_to_float(eqn[0]), fixed_to_float(eqn[1]),
+			  fixed_to_float(eqn[2]), fixed_to_float(eqn[3]) };
 	glClipPlanef(p, eq);
 }
 

--- a/src/fixed_point.c
+++ b/src/fixed_point.c
@@ -1,0 +1,4 @@
+/* fixed_point.c */
+
+#include "fixed_point.h"
+/* Functions are defined as static inline in the header for efficiency. */

--- a/src/fixed_point.h
+++ b/src/fixed_point.h
@@ -1,0 +1,44 @@
+/* fixed_point.h */
+
+#ifndef FIXED_POINT_H
+#define FIXED_POINT_H
+/**
+ * @file fixed_point.h
+ * @brief Fixed point conversion helpers.
+ */
+
+#include <GLES/gl.h>
+#include <stdint.h>
+
+#define FIXED_TO_FLOAT(x) ((GLfloat)(x) / 65536.0f)
+#define FLOAT_TO_FIXED(x) ((GLfixed)((x) * 65536.0f))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline GLfloat fixed_to_float(GLfixed v)
+{
+	return (GLfloat)v / 65536.0f;
+}
+
+static inline GLfixed float_to_fixed(GLfloat f)
+{
+	return (GLfixed)(f * 65536.0f);
+}
+
+static inline GLfixed fixed_mul(GLfixed a, GLfixed b)
+{
+	return (GLfixed)(((int64_t)a * (int64_t)b) >> 16);
+}
+
+static inline GLfixed fixed_div(GLfixed a, GLfixed b)
+{
+	return (GLfixed)(((int64_t)a << 16) / b);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIXED_POINT_H */

--- a/src/gl_api_depthstencil.c
+++ b/src/gl_api_depthstencil.c
@@ -49,7 +49,7 @@ GL_API void GL_APIENTRY glPolygonOffset(GLfloat factor, GLfloat units)
 
 GL_API void GL_APIENTRY glPolygonOffsetx(GLfixed factor, GLfixed units)
 {
-	glPolygonOffset(FIXED_TO_FLOAT(factor), FIXED_TO_FLOAT(units));
+	glPolygonOffset(fixed_to_float(factor), fixed_to_float(units));
 }
 
 GL_API void GL_APIENTRY glClearStencil(GLint s)

--- a/src/gl_api_lighting.c
+++ b/src/gl_api_lighting.c
@@ -62,7 +62,7 @@ GL_API void GL_APIENTRY glLightf(GLenum light, GLenum pname, GLfloat param)
 
 GL_API void GL_APIENTRY glLightx(GLenum light, GLenum pname, GLfixed param)
 {
-	glLightf(light, pname, FIXED_TO_FLOAT(param));
+	glLightf(light, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glLightfv(GLenum light, GLenum pname,
@@ -123,10 +123,10 @@ GL_API void GL_APIENTRY glLightxv(GLenum light, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(params[0]),
-			    FIXED_TO_FLOAT(params[1]),
-			    FIXED_TO_FLOAT(params[2]),
-			    FIXED_TO_FLOAT(params[3]) };
+	GLfloat vals[4] = { fixed_to_float(params[0]),
+			    fixed_to_float(params[1]),
+			    fixed_to_float(params[2]),
+			    fixed_to_float(params[3]) };
 	glLightfv(light, pname, vals);
 }
 
@@ -141,7 +141,7 @@ GL_API void GL_APIENTRY glLightModelf(GLenum pname, GLfloat param)
 
 GL_API void GL_APIENTRY glLightModelx(GLenum pname, GLfixed param)
 {
-	glLightModelf(pname, FIXED_TO_FLOAT(param));
+	glLightModelf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glLightModelfv(GLenum pname, const GLfloat *params)
@@ -170,9 +170,9 @@ GL_API void GL_APIENTRY glLightModelxv(GLenum pname, const GLfixed *param)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(param[0]), FIXED_TO_FLOAT(param[1]),
-			    FIXED_TO_FLOAT(param[2]),
-			    FIXED_TO_FLOAT(param[3]) };
+	GLfloat vals[4] = { fixed_to_float(param[0]), fixed_to_float(param[1]),
+			    fixed_to_float(param[2]),
+			    fixed_to_float(param[3]) };
 	glLightModelfv(pname, vals);
 }
 
@@ -201,7 +201,7 @@ GL_API void GL_APIENTRY glMaterialf(GLenum face, GLenum pname, GLfloat param)
 
 GL_API void GL_APIENTRY glMaterialx(GLenum face, GLenum pname, GLfixed param)
 {
-	glMaterialf(face, pname, FIXED_TO_FLOAT(param));
+	glMaterialf(face, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glMaterialfv(GLenum face, GLenum pname,
@@ -268,8 +268,8 @@ GL_API void GL_APIENTRY glMaterialxv(GLenum face, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(param[0]), FIXED_TO_FLOAT(param[1]),
-			    FIXED_TO_FLOAT(param[2]),
-			    FIXED_TO_FLOAT(param[3]) };
+	GLfloat vals[4] = { fixed_to_float(param[0]), fixed_to_float(param[1]),
+			    fixed_to_float(param[2]),
+			    fixed_to_float(param[3]) };
 	glMaterialfv(face, pname, vals);
 }

--- a/src/gl_api_matrix.c
+++ b/src/gl_api_matrix.c
@@ -186,7 +186,7 @@ GL_API void GL_APIENTRY glLoadMatrixx(const GLfixed *m)
 	}
 	GLfloat mf[16];
 	for (int i = 0; i < 16; ++i)
-		mf[i] = FIXED_TO_FLOAT(m[i]);
+		mf[i] = fixed_to_float(m[i]);
 	glLoadMatrixf(mf);
 }
 
@@ -212,7 +212,7 @@ GL_API void GL_APIENTRY glMultMatrixx(const GLfixed *m)
 	}
 	GLfloat mf[16];
 	for (int i = 0; i < 16; ++i)
-		mf[i] = FIXED_TO_FLOAT(m[i]);
+		mf[i] = fixed_to_float(m[i]);
 	glMultMatrixf(mf);
 }
 

--- a/src/gl_api_misc.c
+++ b/src/gl_api_misc.c
@@ -28,10 +28,10 @@ GL_API void GL_APIENTRY glClipPlanex(GLenum plane, const GLfixed *equation)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat eq[4] = { FIXED_TO_FLOAT(equation[0]),
-			  FIXED_TO_FLOAT(equation[1]),
-			  FIXED_TO_FLOAT(equation[2]),
-			  FIXED_TO_FLOAT(equation[3]) };
+	GLfloat eq[4] = { fixed_to_float(equation[0]),
+			  fixed_to_float(equation[1]),
+			  fixed_to_float(equation[2]),
+			  fixed_to_float(equation[3]) };
 	glClipPlanef(plane, eq);
 }
 
@@ -43,7 +43,7 @@ GL_API void GL_APIENTRY glFogf(GLenum pname, GLfloat param)
 
 GL_API void GL_APIENTRY glFogx(GLenum pname, GLfixed param)
 {
-	glFogf(pname, FIXED_TO_FLOAT(param));
+	glFogf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glFogxv(GLenum pname, const GLfixed *param)
@@ -52,9 +52,9 @@ GL_API void GL_APIENTRY glFogxv(GLenum pname, const GLfixed *param)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(param[0]), FIXED_TO_FLOAT(param[1]),
-			    FIXED_TO_FLOAT(param[2]),
-			    FIXED_TO_FLOAT(param[3]) };
+	GLfloat vals[4] = { fixed_to_float(param[0]), fixed_to_float(param[1]),
+			    fixed_to_float(param[2]),
+			    fixed_to_float(param[3]) };
 	glFogfv(pname, vals);
 }
 
@@ -113,7 +113,7 @@ GL_API void GL_APIENTRY glGetClipPlanex(GLenum plane, GLfixed *equation)
 	GLfloat eq[4];
 	glGetClipPlanef(plane, eq);
 	for (int i = 0; i < 4; ++i)
-		equation[i] = FLOAT_TO_FIXED(eq[i]);
+		equation[i] = float_to_fixed(eq[i]);
 }
 
 GL_API void GL_APIENTRY glGetLightfv(GLenum light, GLenum pname,
@@ -157,7 +157,7 @@ GL_API void GL_APIENTRY glGetLightxv(GLenum light, GLenum pname,
 	GLfloat tmp[4];
 	glGetLightfv(light, pname, tmp);
 	for (int i = 0; i < 4; ++i)
-		params[i] = FLOAT_TO_FIXED(tmp[i]);
+		params[i] = float_to_fixed(tmp[i]);
 }
 
 GL_API void GL_APIENTRY glGetMaterialfv(GLenum face, GLenum pname,
@@ -216,7 +216,7 @@ GL_API void GL_APIENTRY glGetMaterialxv(GLenum face, GLenum pname,
 	GLfloat tmp[4];
 	glGetMaterialfv(face, pname, tmp);
 	for (int i = 0; i < 4; ++i)
-		params[i] = FLOAT_TO_FIXED(tmp[i]);
+		params[i] = float_to_fixed(tmp[i]);
 }
 
 GL_API void GL_APIENTRY glGetTexEnvfv(GLenum target, GLenum pname,
@@ -265,7 +265,7 @@ GL_API void GL_APIENTRY glGetTexEnvxv(GLenum target, GLenum pname,
 	GLfloat tmp[4];
 	glGetTexEnvfv(target, pname, tmp);
 	for (int i = 0; i < 4; ++i)
-		params[i] = FLOAT_TO_FIXED(tmp[i]);
+		params[i] = float_to_fixed(tmp[i]);
 }
 
 GL_API void GL_APIENTRY glGetTexParameterfv(GLenum target, GLenum pname,
@@ -308,12 +308,12 @@ GL_API void GL_APIENTRY glGetTexParameterfv(GLenum target, GLenum pname,
 
 GL_API void GL_APIENTRY glAlphaFuncx(GLenum func, GLfixed ref)
 {
-	glAlphaFunc(func, FIXED_TO_FLOAT(ref));
+	glAlphaFunc(func, fixed_to_float(ref));
 }
 
 GL_API void GL_APIENTRY glClearDepthx(GLfixed depth)
 {
-	glClearDepthf(FIXED_TO_FLOAT(depth));
+	glClearDepthf(fixed_to_float(depth));
 }
 
 GL_API void GL_APIENTRY glColor4ub(GLubyte red, GLubyte green, GLubyte blue,
@@ -324,8 +324,8 @@ GL_API void GL_APIENTRY glColor4ub(GLubyte red, GLubyte green, GLubyte blue,
 
 GL_API void GL_APIENTRY glColor4x(GLfixed r, GLfixed g, GLfixed b, GLfixed a)
 {
-	glColor4f(FIXED_TO_FLOAT(r), FIXED_TO_FLOAT(g), FIXED_TO_FLOAT(b),
-		  FIXED_TO_FLOAT(a));
+	glColor4f(fixed_to_float(r), fixed_to_float(g), fixed_to_float(b),
+		  fixed_to_float(a));
 }
 
 GL_API void GL_APIENTRY glColor4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a)
@@ -339,19 +339,19 @@ GL_API void GL_APIENTRY glColor4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a)
 
 GL_API void GL_APIENTRY glDepthRangex(GLfixed n, GLfixed f)
 {
-	glDepthRangef(FIXED_TO_FLOAT(n), FIXED_TO_FLOAT(f));
+	glDepthRangef(fixed_to_float(n), fixed_to_float(f));
 }
 
 GL_API void GL_APIENTRY glFrustumx(GLfixed l, GLfixed r, GLfixed b, GLfixed t,
 				   GLfixed n, GLfixed f)
 {
-	glFrustumf(FIXED_TO_FLOAT(l), FIXED_TO_FLOAT(r), FIXED_TO_FLOAT(b),
-		   FIXED_TO_FLOAT(t), FIXED_TO_FLOAT(n), FIXED_TO_FLOAT(f));
+	glFrustumf(fixed_to_float(l), fixed_to_float(r), fixed_to_float(b),
+		   fixed_to_float(t), fixed_to_float(n), fixed_to_float(f));
 }
 
 GL_API void GL_APIENTRY glLineWidthx(GLfixed width)
 {
-	glLineWidth(FIXED_TO_FLOAT(width));
+	glLineWidth(fixed_to_float(width));
 }
 
 GL_API void GL_APIENTRY glLineWidth(GLfloat width)
@@ -381,8 +381,8 @@ GL_API void GL_APIENTRY glMultiTexCoord4f(GLenum target, GLfloat s, GLfloat t,
 GL_API void GL_APIENTRY glMultiTexCoord4x(GLenum texture, GLfixed s, GLfixed t,
 					  GLfixed r, GLfixed q)
 {
-	glMultiTexCoord4f(texture, FIXED_TO_FLOAT(s), FIXED_TO_FLOAT(t),
-			  FIXED_TO_FLOAT(r), FIXED_TO_FLOAT(q));
+	glMultiTexCoord4f(texture, fixed_to_float(s), fixed_to_float(t),
+			  fixed_to_float(r), fixed_to_float(q));
 }
 
 GL_API void GL_APIENTRY glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz)
@@ -395,21 +395,21 @@ GL_API void GL_APIENTRY glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz)
 
 GL_API void GL_APIENTRY glNormal3x(GLfixed nx, GLfixed ny, GLfixed nz)
 {
-	glNormal3f(FIXED_TO_FLOAT(nx), FIXED_TO_FLOAT(ny), FIXED_TO_FLOAT(nz));
+	glNormal3f(fixed_to_float(nx), fixed_to_float(ny), fixed_to_float(nz));
 }
 
 GL_API void GL_APIENTRY glOrthox(GLfixed l, GLfixed r, GLfixed b, GLfixed t,
 				 GLfixed n, GLfixed f)
 {
-	glOrthof(FIXED_TO_FLOAT(l), FIXED_TO_FLOAT(r), FIXED_TO_FLOAT(b),
-		 FIXED_TO_FLOAT(t), FIXED_TO_FLOAT(n), FIXED_TO_FLOAT(f));
+	glOrthof(fixed_to_float(l), fixed_to_float(r), fixed_to_float(b),
+		 fixed_to_float(t), fixed_to_float(n), fixed_to_float(f));
 }
 
 GL_API void GL_APIENTRY glRotatex(GLfixed angle, GLfixed x, GLfixed y,
 				  GLfixed z)
 {
-	glRotatef(FIXED_TO_FLOAT(angle), FIXED_TO_FLOAT(x), FIXED_TO_FLOAT(y),
-		  FIXED_TO_FLOAT(z));
+	glRotatef(fixed_to_float(angle), fixed_to_float(x), fixed_to_float(y),
+		  fixed_to_float(z));
 }
 
 GL_API void GL_APIENTRY glSampleCoverage(GLclampf value, GLboolean invert)
@@ -424,17 +424,17 @@ GL_API void GL_APIENTRY glSampleCoverage(GLclampf value, GLboolean invert)
 
 GL_API void GL_APIENTRY glSampleCoveragex(GLclampx value, GLboolean invert)
 {
-	glSampleCoverage(FIXED_TO_FLOAT(value), invert);
+	glSampleCoverage(fixed_to_float(value), invert);
 }
 
 GL_API void GL_APIENTRY glScalex(GLfixed x, GLfixed y, GLfixed z)
 {
-	glScalef(FIXED_TO_FLOAT(x), FIXED_TO_FLOAT(y), FIXED_TO_FLOAT(z));
+	glScalef(fixed_to_float(x), fixed_to_float(y), fixed_to_float(z));
 }
 
 GL_API void GL_APIENTRY glTranslatex(GLfixed x, GLfixed y, GLfixed z)
 {
-	glTranslatef(FIXED_TO_FLOAT(x), FIXED_TO_FLOAT(y), FIXED_TO_FLOAT(z));
+	glTranslatef(fixed_to_float(x), fixed_to_float(y), fixed_to_float(z));
 }
 
 GL_API void GL_APIENTRY glFinish(void)

--- a/src/gl_api_pixels.c
+++ b/src/gl_api_pixels.c
@@ -103,8 +103,8 @@ GL_API void GL_APIENTRY glClearColor(GLfloat red, GLfloat green, GLfloat blue,
 GL_API void GL_APIENTRY glClearColorx(GLfixed red, GLfixed green, GLfixed blue,
 				      GLfixed alpha)
 {
-	glClearColor(FIXED_TO_FLOAT(red), FIXED_TO_FLOAT(green),
-		     FIXED_TO_FLOAT(blue), FIXED_TO_FLOAT(alpha));
+	glClearColor(fixed_to_float(red), fixed_to_float(green),
+		     fixed_to_float(blue), fixed_to_float(alpha));
 }
 
 GL_API void GL_APIENTRY glPointSize(GLfloat size)
@@ -118,7 +118,7 @@ GL_API void GL_APIENTRY glPointSize(GLfloat size)
 
 GL_API void GL_APIENTRY glPointSizex(GLfixed size)
 {
-	glPointSize(FIXED_TO_FLOAT(size));
+	glPointSize(fixed_to_float(size));
 }
 
 GL_API void GL_APIENTRY glPointParameterf(GLenum pname, GLfloat param)
@@ -141,7 +141,7 @@ GL_API void GL_APIENTRY glPointParameterf(GLenum pname, GLfloat param)
 
 GL_API void GL_APIENTRY glPointParameterx(GLenum pname, GLfixed param)
 {
-	glPointParameterf(pname, FIXED_TO_FLOAT(param));
+	glPointParameterf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glPointParameterfv(GLenum pname, const GLfloat *params)
@@ -159,7 +159,7 @@ GL_API void GL_APIENTRY glPointParameterxv(GLenum pname, const GLfixed *params)
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	glPointParameterf(pname, FIXED_TO_FLOAT(params[0]));
+	glPointParameterf(pname, fixed_to_float(params[0]));
 }
 
 GL_API void GL_APIENTRY glPixelStorei(GLenum pname, GLint param)
@@ -185,12 +185,12 @@ GL_API void GL_APIENTRY glPixelStorei(GLenum pname, GLint param)
 
 GL_API void GL_APIENTRY glPointSizexOES(GLfixed size)
 {
-	glPointSize(FIXED_TO_FLOAT(size));
+	glPointSize(fixed_to_float(size));
 }
 
 GL_API void GL_APIENTRY glPointParameterxOES(GLenum pname, GLfixed param)
 {
-	glPointParameterf(pname, FIXED_TO_FLOAT(param));
+	glPointParameterf(pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glPointParameterxvOES(GLenum pname,
@@ -200,7 +200,7 @@ GL_API void GL_APIENTRY glPointParameterxvOES(GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	glPointParameterf(pname, FIXED_TO_FLOAT(params[0]));
+	glPointParameterf(pname, fixed_to_float(params[0]));
 }
 
 GL_API void GL_APIENTRY glPointParameterfOES(GLenum pname, GLfloat param)

--- a/src/gl_api_state.c
+++ b/src/gl_api_state.c
@@ -551,7 +551,7 @@ GL_API void GL_APIENTRY glGetFixedv(GLenum pname, GLfixed *params)
 	GLfloat tmp[16] = { 0 };
 	glGetFloatv(pname, tmp);
 	for (int i = 0; i < 16; ++i)
-		params[i] = FLOAT_TO_FIXED(tmp[i]);
+		params[i] = float_to_fixed(tmp[i]);
 }
 
 GL_API void GL_APIENTRY glGetIntegerv(GLenum pname, GLint *data)

--- a/src/gl_api_texture.c
+++ b/src/gl_api_texture.c
@@ -63,7 +63,7 @@ GL_API void GL_APIENTRY glTexParameterfv(GLenum target, GLenum pname,
 GL_API void GL_APIENTRY glTexParameterx(GLenum target, GLenum pname,
 					GLfixed param)
 {
-	glTexParameterf(target, pname, FIXED_TO_FLOAT(param));
+	glTexParameterf(target, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glTexParameteriv(GLenum target, GLenum pname,
@@ -83,17 +83,17 @@ GL_API void GL_APIENTRY glTexParameterxv(GLenum target, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(params[0]),
-			    FIXED_TO_FLOAT(params[1]),
-			    FIXED_TO_FLOAT(params[2]),
-			    FIXED_TO_FLOAT(params[3]) };
+	GLfloat vals[4] = { fixed_to_float(params[0]),
+			    fixed_to_float(params[1]),
+			    fixed_to_float(params[2]),
+			    fixed_to_float(params[3]) };
 	glTexParameterfv(target, pname, vals);
 }
 
 GL_API void GL_APIENTRY glTexParameterxOES(GLenum target, GLenum pname,
 					   GLfixed param)
 {
-	glTexParameterf(target, pname, FIXED_TO_FLOAT(param));
+	glTexParameterf(target, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glTexParameterxvOES(GLenum target, GLenum pname,
@@ -103,10 +103,10 @@ GL_API void GL_APIENTRY glTexParameterxvOES(GLenum target, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(params[0]),
-			    FIXED_TO_FLOAT(params[1]),
-			    FIXED_TO_FLOAT(params[2]),
-			    FIXED_TO_FLOAT(params[3]) };
+	GLfloat vals[4] = { fixed_to_float(params[0]),
+			    fixed_to_float(params[1]),
+			    fixed_to_float(params[2]),
+			    fixed_to_float(params[3]) };
 	glTexParameterfv(target, pname, vals);
 }
 
@@ -325,7 +325,7 @@ GL_API void GL_APIENTRY glTexEnvi(GLenum target, GLenum pname, GLint param)
 
 GL_API void GL_APIENTRY glTexEnvx(GLenum target, GLenum pname, GLfixed param)
 {
-	glTexEnvf(target, pname, FIXED_TO_FLOAT(param));
+	glTexEnvf(target, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glTexEnviv(GLenum target, GLenum pname,
@@ -345,16 +345,16 @@ GL_API void GL_APIENTRY glTexEnvxv(GLenum target, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(params[0]),
-			    FIXED_TO_FLOAT(params[1]),
-			    FIXED_TO_FLOAT(params[2]),
-			    FIXED_TO_FLOAT(params[3]) };
+	GLfloat vals[4] = { fixed_to_float(params[0]),
+			    fixed_to_float(params[1]),
+			    fixed_to_float(params[2]),
+			    fixed_to_float(params[3]) };
 	glTexEnvfv(target, pname, vals);
 }
 
 GL_API void GL_APIENTRY glTexEnvxOES(GLenum target, GLenum pname, GLfixed param)
 {
-	glTexEnvf(target, pname, FIXED_TO_FLOAT(param));
+	glTexEnvf(target, pname, fixed_to_float(param));
 }
 
 GL_API void GL_APIENTRY glTexEnvxvOES(GLenum target, GLenum pname,
@@ -364,9 +364,9 @@ GL_API void GL_APIENTRY glTexEnvxvOES(GLenum target, GLenum pname,
 		glSetError(GL_INVALID_VALUE);
 		return;
 	}
-	GLfloat vals[4] = { FIXED_TO_FLOAT(params[0]),
-			    FIXED_TO_FLOAT(params[1]),
-			    FIXED_TO_FLOAT(params[2]),
-			    FIXED_TO_FLOAT(params[3]) };
+	GLfloat vals[4] = { fixed_to_float(params[0]),
+			    fixed_to_float(params[1]),
+			    fixed_to_float(params[2]),
+			    fixed_to_float(params[3]) };
 	glTexEnvfv(target, pname, vals);
 }

--- a/src/gl_utils.h
+++ b/src/gl_utils.h
@@ -10,6 +10,7 @@
 #include <GLES/gl.h> /* OpenGL ES 1.1 */
 #include <GLES/glext.h> /* For extension types */
 #include <stddef.h> /* For size_t */
+#include "fixed_point.h" /* Fixed-point helpers */
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,9 +19,6 @@ extern "C" {
 /* Memory tracking functions */
 void *tracked_malloc(size_t size);
 void tracked_free(void *ptr, size_t size);
-
-#define FIXED_TO_FLOAT(x) ((GLfloat)(x) / 65536.0f)
-#define FLOAT_TO_FIXED(x) ((GLfixed)((x) * 65536.0f))
 
 /* Utility function to validate framebuffer completeness */
 GLboolean ValidateFramebufferCompleteness(void);


### PR DESCRIPTION
## Summary
- add new `fixed_point.c`/`fixed_point.h` with inline helpers
- convert macro use sites to `fixed_to_float`/`float_to_fixed`
- remove duplicate fixed-point macro from `gl_extensions.c`
- build fixed_point.c in CMake

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6857ebd89f9c8325a33c4f608d5a772e