### PR TITLE
Add tests for OES fixed-point functions

### DIFF
--- a/conformance/CMakeLists.txt
+++ b/conformance/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CONFORMANCE_SOURCES
     src/tests/texture_cache.c
     src/tests/thread_stress.c
     src/tests/point_sprite.c
+    src/tests/fixed_point.c
     src/tests/all_calls.c
     src/tests/extensions.c
     src/tests/util.c

--- a/conformance/src/tests.h
+++ b/conformance/src/tests.h
@@ -44,6 +44,7 @@ const struct Test *get_thread_stress_tests(size_t *count);
 const struct Test *get_autogen_tests(size_t *count);
 const struct Test *get_all_calls_tests(size_t *count);
 const struct Test *get_point_sprite_tests(size_t *count);
+const struct Test *get_fixed_point_tests(size_t *count);
 
 #ifdef __cplusplus
 }

--- a/conformance/src/tests/fixed_point.c
+++ b/conformance/src/tests/fixed_point.c
@@ -1,0 +1,62 @@
+#include "tests.h"
+#define GL_GLEXT_PROTOTYPES
+#include <GLES/glext.h>
+#include <math.h>
+
+#define FIXED(x) ((GLfixed)((x) * 65536))
+#define ENUM_X(e) ((GLfixed)((e) << 16))
+
+static int test_clear_colorx(void)
+{
+	glClearColorxOES(FIXED(0.25f), FIXED(0.5f), FIXED(0.75f), FIXED(1.0f));
+	GLfixed val[4] = { 0 };
+	glGetFixedvOES(GL_COLOR_CLEAR_VALUE, val);
+	CHECK_OK(val[0] == FIXED(0.25f) && val[1] == FIXED(0.5f) &&
+		 val[2] == FIXED(0.75f) && val[3] == FIXED(1.0f));
+	CHECK_GLError(GL_NO_ERROR);
+	return 1;
+}
+
+static int test_scalex(void)
+{
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	glScalexOES(FIXED(2.0f), FIXED(3.0f), FIXED(1.0f));
+	GLfloat matf[16];
+	glGetFloatv(GL_MODELVIEW_MATRIX, matf);
+	CHECK_OK(fabsf(matf[0] - 2.0f) < 0.001f &&
+		 fabsf(matf[5] - 3.0f) < 0.001f &&
+		 fabsf(matf[10] - 1.0f) < 0.001f &&
+		 fabsf(matf[15] - 1.0f) < 0.001f);
+	CHECK_GLError(GL_NO_ERROR);
+	return 1;
+}
+
+static int test_tex_parameterx(void)
+{
+	GLuint tex;
+	glGenTextures(1, &tex);
+	glBindTexture(GL_TEXTURE_2D, tex);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2, 2, 0, GL_RGBA,
+		     GL_UNSIGNED_BYTE, NULL);
+	glTexParameterxOES(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+			   ENUM_X(GL_NEAREST));
+	GLfixed vals[4];
+	glGetTexParameterxvOES(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, vals);
+	glDeleteTextures(1, &tex);
+	CHECK_OK(vals[0] == ENUM_X(GL_NEAREST));
+	CHECK_GLError(GL_NO_ERROR);
+	return 1;
+}
+
+static const struct Test tests[] = {
+	{ "clear_colorx", test_clear_colorx },
+	{ "scalex", test_scalex },
+	{ "tex_parameterx", test_tex_parameterx },
+};
+
+const struct Test *get_fixed_point_tests(size_t *count)
+{
+	*count = sizeof(tests) / sizeof(tests[0]);
+	return tests;
+}

--- a/conformance/src/tests_main.c
+++ b/conformance/src/tests_main.c
@@ -80,6 +80,7 @@ int main(int argc, char **argv)
 	RUN(get_fbo_tests);
 	RUN(get_depth_tests);
 	RUN(get_extensions_tests);
+	RUN(get_fixed_point_tests);
 	RUN(get_thread_stress_tests);
 	RUN(get_point_sprite_tests);
 	RUN(get_autogen_tests);


### PR DESCRIPTION
## Summary
- add new `fixed_point.c` tests for GL_OES_fixed_point APIs
- register tests in the conformance build system
- expose new test group in the public test headers and main runner

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6857f21c76848325bf59907b464117c3