### PR TITLE
Add restrict qualifiers to pipeline hot paths

### DIFF
--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -121,8 +121,8 @@ void framebuffer_destroy(Framebuffer *fb)
 	framebuffer_release(fb);
 }
 
-void framebuffer_clear(Framebuffer *fb, uint32_t clear_color, float clear_depth,
-		       uint8_t clear_stencil)
+void framebuffer_clear(Framebuffer *restrict fb, uint32_t clear_color,
+		       float clear_depth, uint8_t clear_stencil)
 {
 	size_t total = (size_t)fb->width * fb->height;
 	size_t i = 0;
@@ -180,7 +180,7 @@ void framebuffer_clear_async(Framebuffer *fb, uint32_t clear_color,
 	command_buffer_record_task(clear_task_func, task, STAGE_FRAMEBUFFER);
 }
 
-void framebuffer_set_pixel(Framebuffer *fb, uint32_t x, uint32_t y,
+void framebuffer_set_pixel(Framebuffer *restrict fb, uint32_t x, uint32_t y,
 			   uint32_t color, float depth)
 {
 	if (x >= fb->width || y >= fb->height)

--- a/src/pipeline/gl_framebuffer.h
+++ b/src/pipeline/gl_framebuffer.h
@@ -43,9 +43,9 @@ Framebuffer *framebuffer_create(uint32_t width, uint32_t height);
 void framebuffer_destroy(Framebuffer *fb);
 void framebuffer_retain(Framebuffer *fb);
 void framebuffer_release(Framebuffer *fb);
-void framebuffer_clear(Framebuffer *fb, uint32_t clear_color, float clear_depth,
-		       uint8_t clear_stencil);
-void framebuffer_set_pixel(Framebuffer *fb, uint32_t x, uint32_t y,
+void framebuffer_clear(Framebuffer *restrict fb, uint32_t clear_color,
+		       float clear_depth, uint8_t clear_stencil);
+void framebuffer_set_pixel(Framebuffer *restrict fb, uint32_t x, uint32_t y,
 			   uint32_t color, float depth);
 void framebuffer_fill_rect(Framebuffer *fb, uint32_t x0, uint32_t y0,
 			   uint32_t x1, uint32_t y1, uint32_t color,

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -17,8 +17,9 @@ static uint32_t pack_color(const GLfloat c[4])
 	return (a << 24) | (b << 16) | (g << 8) | r;
 }
 
-void pipeline_rasterize_triangle(const Triangle *tri, const GLint viewport[4],
-				 Framebuffer *fb)
+void pipeline_rasterize_triangle(const Triangle *restrict tri,
+				 const GLint *restrict viewport,
+				 Framebuffer *restrict fb)
 {
 	float minx = tri->v0.x;
 	float maxx = tri->v0.x;
@@ -102,8 +103,9 @@ void pipeline_rasterize_triangle(const Triangle *tri, const GLint viewport[4],
 	}
 }
 
-void pipeline_rasterize_point(const Vertex *v, GLfloat size,
-			      const GLint viewport[4], Framebuffer *fb)
+void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
+			      const GLint *restrict viewport,
+			      Framebuffer *restrict fb)
 {
 	int half = (int)(size * 0.5f);
 	int x0 = (int)(v->x - half);

--- a/src/pipeline/gl_raster.h
+++ b/src/pipeline/gl_raster.h
@@ -8,10 +8,12 @@
 extern "C" {
 #endif
 
-void pipeline_rasterize_triangle(const Triangle *tri, const GLint viewport[4],
-				 Framebuffer *fb);
-void pipeline_rasterize_point(const Vertex *v, GLfloat size,
-			      const GLint viewport[4], Framebuffer *fb);
+void pipeline_rasterize_triangle(const Triangle *restrict tri,
+				 const GLint *restrict viewport,
+				 Framebuffer *restrict fb);
+void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
+			      const GLint *restrict viewport,
+			      Framebuffer *restrict fb);
 
 #define TILE_SIZE 16
 

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -19,8 +19,10 @@ _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
  * This file performs object->clip transformations and lighting.
  */
 
-void pipeline_transform_vertex(Vertex *dst, const Vertex *src, const mat4 *mvp,
-			       const mat4 *normal_mat, const GLint viewport[4])
+void pipeline_transform_vertex(Vertex *restrict dst, const Vertex *restrict src,
+			       const mat4 *restrict mvp,
+			       const mat4 *restrict normal_mat,
+			       const GLint *restrict viewport)
 {
 	GLfloat in[4] = { src->x, src->y, src->z, src->w };
 	GLfloat out[4];

--- a/src/pipeline/gl_vertex.h
+++ b/src/pipeline/gl_vertex.h
@@ -15,8 +15,10 @@ typedef struct {
 	GLint viewport[4];
 } VertexJob;
 
-void pipeline_transform_vertex(Vertex *dst, const Vertex *src, const mat4 *mvp,
-			       const mat4 *normal_mat, const GLint viewport[4]);
+void pipeline_transform_vertex(Vertex *restrict dst, const Vertex *restrict src,
+			       const mat4 *restrict mvp,
+			       const mat4 *restrict normal_mat,
+			       const GLint *restrict viewport);
 void process_vertex_job(void *task_data);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- mark frame buffer, raster, and vertex functions' pointer parameters as `restrict`
- propagate qualifiers across headers and sources

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6857feb35e8c8325808d5ad4ba53ff78