### PR TITLE
Align framebuffer buffers

### DIFF
--- a/src/gl_utils.c
+++ b/src/gl_utils.c
@@ -20,6 +20,28 @@ void *tracked_malloc(size_t size)
 	return ptr;
 }
 
+/* Function to allocate aligned memory with tracking */
+void *tracked_aligned_alloc(size_t alignment, size_t size)
+{
+	void *ptr = MT_ALIGNED_ALLOC(alignment, size, STAGE_FRAMEBUFFER);
+	if (!ptr) {
+		LOG_WARN(
+			"tracked_aligned_alloc: falling back to unaligned malloc");
+		ptr = MT_ALLOC(size, STAGE_FRAMEBUFFER);
+		if (!ptr) {
+			LOG_ERROR(
+				"tracked_aligned_alloc: Failed to allocate %zu bytes.",
+				size);
+			glSetError(GL_OUT_OF_MEMORY);
+		}
+	} else {
+		LOG_DEBUG(
+			"tracked_aligned_alloc: Allocated %zu bytes (al %zu) at %p.",
+			size, alignment, ptr);
+	}
+	return ptr;
+}
+
 /* Function to free memory with tracking */
 void tracked_free(void *ptr, size_t size)
 {

--- a/src/gl_utils.h
+++ b/src/gl_utils.h
@@ -18,6 +18,7 @@ extern "C" {
 
 /* Memory tracking functions */
 void *tracked_malloc(size_t size);
+void *tracked_aligned_alloc(size_t alignment, size_t size);
 void tracked_free(void *ptr, size_t size);
 
 /* Utility function to validate framebuffer completeness */

--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -41,12 +41,12 @@ Framebuffer *framebuffer_create(uint32_t width, uint32_t height)
 	fb->height = height;
 	atomic_init(&fb->ref_count, 1);
 	size_t pixels = (size_t)width * height;
-	fb->color_buffer = (_Atomic uint32_t *)tracked_malloc(
-		pixels * sizeof(_Atomic uint32_t));
-	fb->depth_buffer =
-		(_Atomic float *)tracked_malloc(pixels * sizeof(_Atomic float));
-	fb->stencil_buffer = (_Atomic uint8_t *)tracked_malloc(
-		pixels * sizeof(_Atomic uint8_t));
+	fb->color_buffer = (_Atomic uint32_t *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic uint32_t));
+	fb->depth_buffer = (_Atomic float *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic float));
+	fb->stencil_buffer = (_Atomic uint8_t *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic uint8_t));
 	if (!fb->color_buffer || !fb->depth_buffer || !fb->stencil_buffer) {
 		if (fb->color_buffer)
 			tracked_free(fb->color_buffer,


### PR DESCRIPTION
## Summary
- add tracked_aligned_alloc helper
- align framebuffer buffer allocations
- allow fallback to malloc inside memory tracker

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6858098e08b08325b8973a380eefb5c1