### PR TITLE
Add generic math helpers

### DIFF
--- a/src/c11_opt.h
+++ b/src/c11_opt.h
@@ -7,4 +7,11 @@
 #define GL_SQRT(x) _Generic((x), float: sqrtf, double: sqrt)((x))
 #define GL_POW(x, y) _Generic((x), float: powf, double: pow)((x), (y))
 
+/* Additional helpers */
+#define GL_ABS(x) _Generic((x), float: fabsf, double: fabs)((x))
+#define GL_MIN(x, y) _Generic((x), float: fminf, double: fmin)((x), (y))
+#define GL_MAX(x, y) _Generic((x), float: fmaxf, double: fmax)((x), (y))
+#define GL_CLAMP(x, lo, hi) (GL_MIN(GL_MAX((x), (lo)), (hi)))
+#define GL_LERP(a, b, t) ((a) + ((b) - (a)) * (t))
+
 #endif /* C11_OPT_H */

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -102,8 +102,7 @@ static void apply_lighting(Vertex *v)
 				    lt->linear_attenuation * dist +
 				    lt->quadratic_attenuation * dist * dist);
 		float dot = nx * lx + ny * ly + nz * lz;
-		if (dot < 0.0f)
-			dot = 0.0f;
+		dot = GL_MAX(dot, 0.0f);
 		float hx = lx;
 		float hy = ly;
 		float hz = lz + 1.0f;
@@ -111,8 +110,7 @@ static void apply_lighting(Vertex *v)
 		if (hx != 0.0f || hy != 0.0f || hz != 0.0f) {
 			vec3_normalize(&hx, &hy, &hz);
 			float spec_dot = nx * hx + ny * hy + nz * hz;
-			if (spec_dot < 0.0f)
-				spec_dot = 0.0f;
+			spec_dot = GL_MAX(spec_dot, 0.0f);
 			spec = GL_POW(spec_dot, tl_mat.shininess);
 		}
 		r += tl_mat.ambient[0] * lt->ambient[0] * att +


### PR DESCRIPTION
## Summary
- add more `_Generic` math wrappers in `c11_opt.h`
- use the wrappers in pipeline code

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68580dcf8c0483259c03de04bad51da7