### PR TITLE
Fix build warning for glTexGenfvOES

### DIFF
--- a/src/extensions/gl_ext_OES_fixed_point.c
+++ b/src/extensions/gl_ext_OES_fixed_point.c
@@ -22,6 +22,10 @@
 EXT_REGISTER("GL_OES_fixed_point")
 __attribute__((used)) int ext_link_dummy_OES_fixed_point = 0;
 
+/* Forward declarations for internal helpers */
+GL_API void GL_APIENTRY glTexGenfvOES(GLenum coord, GLenum pname,
+				      const GLfloat *params);
+
 GL_API void GL_APIENTRY glAlphaFuncxOES(GLenum func, GLfixed ref)
 {
 	glAlphaFuncx(func, ref);


### PR DESCRIPTION
## Summary
- forward declare `glTexGenfvOES` in `gl_ext_OES_fixed_point.c`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_6858177a26dc8325845992c16b15f3f3