### PR TITLE
Improve perf monitor console output

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -144,10 +144,16 @@ int main(int argc, char **argv)
 		double cpu_us = thread_cycles_to_us(cend - cstart);
 		double cpu_pct = wall > 0.0 ? (cpu_us / (wall * 1e6)) * 100.0 :
 					      0.0;
-		printf("TID %ld | Mem %zu KB | CPU %5.1f%% | Poly %6.2f MP/s | Pix %6.2f MP/s\n",
-		       get_tid(), memory_tracker_current() / 1024, cpu_pct,
+		static bool header_printed = false;
+		if (!header_printed) {
+			printf("%-7s %-10s %-6s %-11s %-11s\n", "TID",
+			       "Mem(KB)", "CPU%", "Poly(MP/s)", "Pix(MP/s)");
+			header_printed = true;
+		}
+		printf("%7ld %10zu %6.1f %11.2f %11.2f\n", get_tid(),
+		       memory_tracker_current() / 1024, cpu_pct,
 		       polys / wall / 1e6, pix / wall / 1e6);
-		thread_profile_report();
+		thread_realtime_report();
 		thread_profile_start();
 	}
 #ifdef HAVE_X11

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -599,6 +599,30 @@ void thread_profile_report(void)
 	function_profile_report();
 }
 
+void thread_realtime_report(void)
+{
+	static bool header_printed = false;
+	uint64_t gq =
+		atomic_load_explicit(&g_global_tail, memory_order_relaxed) -
+		atomic_load_explicit(&g_global_head, memory_order_relaxed);
+	if (!header_printed) {
+		printf("%-8s", "GQueue");
+		for (int i = 0; i < g_num_threads; ++i)
+			printf(" LQ%d ", i);
+		printf("\n");
+		header_printed = true;
+	}
+	printf("%8llu", (unsigned long long)gq);
+	for (int i = 0; i < g_num_threads; ++i) {
+		uint64_t depth = atomic_load_explicit(&g_local_queues[i].tail,
+						      memory_order_relaxed) -
+				 atomic_load_explicit(&g_local_queues[i].head,
+						      memory_order_relaxed);
+		printf(" %4llu", (unsigned long long)depth);
+	}
+	printf("\n");
+}
+
 texture_cache_t *thread_get_texture_cache(void)
 {
 	return tls_cache;

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -40,6 +40,7 @@ bool thread_pool_active(void);
 void thread_profile_start(void);
 void thread_profile_stop(void);
 void thread_profile_report(void);
+void thread_realtime_report(void);
 bool thread_profile_is_enabled(void);
 uint64_t thread_get_cycles(void);
 uint64_t thread_cycles_to_us(uint64_t cycles);


### PR DESCRIPTION
## Summary
- add thread_realtime_report for queue depths
- display queue depth info during perf monitor

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_68581eacc144832588c7d3c4e0db2b8d