### PR TITLE
Add pyramid helpers to perf monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCE_FILES
     src/ktx_loader.c
     src/command_buffer.c
     src/x11_window.c
+    src/glx.c
     src/gl_init.c
     src/pipeline/gl_framebuffer.c
     src/pipeline/gl_vertex.c

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No SIMD intrinsics or platform APIs are required; only a C11 toolchain is needed
 |---------------------|----------------------------------------------------------------------|
 | **Fixed-function core** | ✔ Matrix stacks, lighting (8 lights), fog, 2-unit texturing, alpha-test, depth & stencil, blending, scissor, point/line primitives |
 | **Extensions**      | ✔ `OES_framebuffer_object`, `OES_draw_texture`, `OES_point_sprite`, `OES_point_size_array`, `OES_matrix_palette` (stubs for others) |
-| **Utilities**       | ✔ `load_ktx_texture()` helper for KTX image loading                  |
+| **Utilities**       | ✔ `load_ktx_texture()` helper and GLU-style matrix wrappers |
 | **Framebuffer**     | ✔ RGBA8 + 32-bit float depth, atomic CAS writes, morton-swizzled layout |
 | **Threading**       | ✔ Lock-free MPMC queue, built-in command buffer recorder, per-stage profiling (`--profile`) |
 | **Pipeline**        | ✔ 16×16 tiled fragment stage, 4×4 texture block cache                |

--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -9,6 +9,7 @@
 #include "gl_utils.h"
 #ifdef HAVE_X11
 #include "x11_window.h"
+#include <GL/glx.h>
 #endif
 #include <stdio.h>
 #include <string.h>
@@ -16,32 +17,29 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <stdlib.h>
+/* Pyramid benchmark parameters */
+#define SCREEN_WIDTH 1024
+#define SCREEN_HEIGHT 768
+#define NUM_PYRAMIDS 1000
 
-/* Cube geometry reused from stress_test.c */
-static const GLfloat cube_vertices[] = {
-	-0.5f, -0.5f, -0.5f, 0.5f,  -0.5f, -0.5f, 0.5f,	 0.5f,	-0.5f, 0.5f,
-	-0.5f, -0.5f, -0.5f, -0.5f, 0.5f,  -0.5f, -0.5f, -0.5f, 0.5f,  -0.5f,
-	-0.5f, 0.5f,  0.5f,  -0.5f, -0.5f, 0.5f,  0.5f,	 -0.5f, 0.5f,  -0.5f,
-	0.5f,  -0.5f, 0.5f,  0.5f,  -0.5f, 0.5f,  0.5f,	 0.5f,	-0.5f, -0.5f,
-	0.5f,  -0.5f, 0.5f,  0.5f,  0.5f,  0.5f,  -0.5f, -0.5f, 0.5f,  -0.5f,
-	0.5f,  0.5f,  0.5f,  -0.5f, 0.5f,  -0.5f, -0.5f, 0.5f,	-0.5f, 0.5f,
-	0.5f,  -0.5f, 0.5f,  -0.5f, 0.5f,  -0.5f, 0.5f,	 0.5f,	0.5f,  0.5f,
-	-0.5f, 0.5f,  0.5f,  0.5f,  -0.5f, 0.5f,  0.5f,	 -0.5f, -0.5f
-};
-static const GLfloat cube_normals[] = {
-	0, 0,  -1, 0, 0,  -1, 0,  0, -1, 0,  0, -1, 0,	0,  1, 0,  0,  1,
-	0, 0,  1,  0, 0,  1,  -1, 0, 0,	 -1, 0, 0,  -1, 0,  0, -1, 0,  0,
-	1, 0,  0,  1, 0,  0,  1,  0, 0,	 1,  0, 0,  0,	-1, 0, 0,  -1, 0,
-	0, -1, 0,  0, -1, 0,  0,  1, 0,	 0,  1, 0,  0,	1,  0, 0,  1,  0
-};
-static const GLfloat cube_tex[] = { 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0,
-				    1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1,
-				    0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0,
-				    1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1 };
-static const GLubyte cube_indices[] = { 0,  1,	2,  0,	2,  3,	4,  5,	6,
-					4,  6,	7,  8,	9,  10, 8,  10, 11,
-					12, 13, 14, 12, 14, 15, 16, 17, 18,
-					16, 18, 19, 20, 21, 22, 20, 22, 23 };
+typedef struct {
+	GLfloat x, y, z;
+} Vec3;
+
+typedef struct {
+	Vec3 position;
+	Vec3 rotation;
+	Vec3 rotationSpeed;
+} Pyramid;
+
+static Pyramid pyramids[NUM_PYRAMIDS];
+static GLfloat pyramid_vertex_data[18 * 3];
+static GLfloat pyramid_color_data[18 * 4];
+
+static float camera_rot_x = 0.0f;
+static float camera_rot_y = 0.0f;
+static float camera_distance = 300.0f;
 
 static long get_tid(void)
 {
@@ -56,6 +54,94 @@ static double ts_diff(const struct timespec *a, const struct timespec *b)
 {
 	return (double)(a->tv_sec - b->tv_sec) +
 	       (double)(a->tv_nsec - b->tv_nsec) / 1e9;
+}
+
+static void init_gl(void)
+{
+	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	gluPerspective(45.0f, (GLfloat)SCREEN_WIDTH / (GLfloat)SCREEN_HEIGHT,
+		       0.1f, 1000.0f);
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	glEnable(GL_DEPTH_TEST);
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_COLOR_ARRAY);
+}
+
+static void generate_pyramid_geometry(void)
+{
+	float size = 1.5f;
+	float height = 3.0f;
+
+	float apex[3] = { 0.0f, height / 2.0f, 0.0f };
+	float base1[3] = { -size, -height / 2.0f, -size };
+	float base2[3] = { size, -height / 2.0f, -size };
+	float base3[3] = { size, -height / 2.0f, size };
+	float base4[3] = { -size, -height / 2.0f, size };
+
+	GLfloat *p = pyramid_vertex_data;
+#define ADD_VTX(v)             \
+	do {                   \
+		*p++ = (v)[0]; \
+		*p++ = (v)[1]; \
+		*p++ = (v)[2]; \
+	} while (0)
+	ADD_VTX(apex);
+	ADD_VTX(base1);
+	ADD_VTX(base2);
+	ADD_VTX(apex);
+	ADD_VTX(base2);
+	ADD_VTX(base3);
+	ADD_VTX(apex);
+	ADD_VTX(base3);
+	ADD_VTX(base4);
+	ADD_VTX(apex);
+	ADD_VTX(base4);
+	ADD_VTX(base1);
+	ADD_VTX(base1);
+	ADD_VTX(base3);
+	ADD_VTX(base2);
+	ADD_VTX(base1);
+	ADD_VTX(base4);
+	ADD_VTX(base3);
+#undef ADD_VTX
+
+	GLfloat *c = pyramid_color_data;
+	for (int i = 0; i < 6; ++i) {
+		float r = (float)rand() / RAND_MAX;
+		float g = (float)rand() / RAND_MAX;
+		float b = (float)rand() / RAND_MAX;
+		for (int j = 0; j < 3; ++j) {
+			*c++ = r;
+			*c++ = g;
+			*c++ = b;
+			*c++ = 1.0f;
+		}
+	}
+}
+
+static void render_scene(void)
+{
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	glTranslatef(0.0f, 0.0f, -camera_distance);
+	glRotatef(camera_rot_x, 1.0f, 0.0f, 0.0f);
+	glRotatef(camera_rot_y, 0.0f, 1.0f, 0.0f);
+	glVertexPointer(3, GL_FLOAT, 0, pyramid_vertex_data);
+	glColorPointer(4, GL_FLOAT, 0, pyramid_color_data);
+	for (int i = 0; i < NUM_PYRAMIDS; ++i) {
+		glPushMatrix();
+		glTranslatef(pyramids[i].position.x, pyramids[i].position.y,
+			     pyramids[i].position.z);
+		glRotatef(pyramids[i].rotation.x, 1.0f, 0.0f, 0.0f);
+		glRotatef(pyramids[i].rotation.y, 0.0f, 1.0f, 0.0f);
+		glRotatef(pyramids[i].rotation.z, 0.0f, 0.0f, 1.0f);
+		glDrawArrays(GL_TRIANGLES, 0, 18);
+		glPopMatrix();
+	}
 }
 
 int main(int argc, char **argv)
@@ -84,36 +170,32 @@ int main(int argc, char **argv)
 	}
 #ifdef HAVE_X11
 	X11Window *win = x11_window_create(1024, 768, "microGLES Perf");
+	GLXContext glx_ctx = NULL;
+	if (win) {
+		glx_ctx = glXCreateContext(NULL, NULL, NULL, False);
+		glXMakeCurrent(NULL, (GLXDrawable)(uintptr_t)win, glx_ctx);
+	}
 #else
 	X11Window *win = NULL;
 #endif
-	const int cube_count = 12;
+
+	init_gl();
+	generate_pyramid_geometry();
+	for (int i = 0; i < NUM_PYRAMIDS; ++i) {
+		pyramids[i].position.x = (float)(rand() % 300) - 150.0f;
+		pyramids[i].position.y = (float)(rand() % 300) - 150.0f;
+		pyramids[i].position.z = (float)(rand() % 300) - 150.0f;
+		pyramids[i].rotation.x = (float)rand() / RAND_MAX * 360.0f;
+		pyramids[i].rotation.y = (float)rand() / RAND_MAX * 360.0f;
+		pyramids[i].rotation.z = (float)rand() / RAND_MAX * 360.0f;
+		pyramids[i].rotationSpeed.x =
+			((float)rand() / RAND_MAX - 0.5f) * 60.0f;
+		pyramids[i].rotationSpeed.y =
+			((float)rand() / RAND_MAX - 0.5f) * 60.0f;
+		pyramids[i].rotationSpeed.z =
+			((float)rand() / RAND_MAX - 0.5f) * 60.0f;
+	}
 	const int face_pixels = 64 * 64;
-	GLubyte *tex = tracked_malloc(face_pixels * 4);
-	memset(tex, 0xAA, face_pixels * 4);
-	GLuint t;
-	glGenTextures(1, &t);
-	glBindTexture(GL_TEXTURE_2D, t);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 64, 64, 0, GL_RGBA,
-		     GL_UNSIGNED_BYTE, tex);
-	tracked_free(tex, face_pixels * 4);
-	glEnableClientState(GL_VERTEX_ARRAY);
-	glVertexPointer(3, GL_FLOAT, 0, cube_vertices);
-	glEnableClientState(GL_NORMAL_ARRAY);
-	glNormalPointer(GL_FLOAT, 0, cube_normals);
-	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-	glTexCoordPointer(2, GL_FLOAT, 0, cube_tex);
-	glEnable(GL_FOG);
-	glFogf(GL_FOG_DENSITY, 0.5f);
-	glEnable(GL_LIGHTING);
-	glEnable(GL_LIGHT0);
-	glLightModelfv(GL_LIGHT_MODEL_AMBIENT,
-		       (GLfloat[]){ 0.1f, 0.1f, 0.1f, 1.0f });
-	glLightfv(GL_LIGHT0, GL_DIFFUSE, (GLfloat[]){ 0.9f, 0.9f, 0.9f, 1.0f });
-	glLightfv(GL_LIGHT0, GL_POSITION,
-		  (GLfloat[]){ 0.0f, 0.0f, 2.0f, 0.0f });
-	mat4 model;
-	mat4_identity(&model);
 	for (int sec = 0; sec < 10; ++sec) {
 		struct timespec start, now;
 		uint64_t cstart, cend;
@@ -121,21 +203,22 @@ int main(int argc, char **argv)
 		cstart = thread_get_cycles();
 		double polys = 0.0, pix = 0.0;
 		do {
-			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-			for (int c = 0; c < cube_count; ++c) {
-				mat4_rotate_x(&model, 2.0f);
-				mat4_rotate_y(&model, 3.0f);
-				mat4_rotate_z(&model, 1.0f);
-				glLoadMatrixf(model.data);
-				glDrawElements(GL_TRIANGLES, 36,
-					       GL_UNSIGNED_BYTE, cube_indices);
-				polys += 12.0;
-				pix += 6.0 * face_pixels;
+			render_scene();
+			for (int i = 0; i < NUM_PYRAMIDS; ++i) {
+				pyramids[i].rotation.x +=
+					pyramids[i].rotationSpeed.x * 0.016f;
+				pyramids[i].rotation.y +=
+					pyramids[i].rotationSpeed.y * 0.016f;
+				pyramids[i].rotation.z +=
+					pyramids[i].rotationSpeed.z * 0.016f;
 			}
+			polys += NUM_PYRAMIDS * 6.0f;
+			pix += NUM_PYRAMIDS * 6.0f * face_pixels;
 			thread_pool_wait();
 #ifdef HAVE_X11
 			if (win)
-				x11_window_show_image(win, fb);
+				glXSwapBuffers(NULL,
+					       (GLXDrawable)(uintptr_t)win);
 #endif
 			clock_gettime(CLOCK_MONOTONIC, &now);
 		} while (ts_diff(&now, &start) < 1.0);
@@ -151,6 +234,10 @@ int main(int argc, char **argv)
 		thread_profile_start();
 	}
 #ifdef HAVE_X11
+	if (glx_ctx) {
+		glXDestroyContext(NULL, glx_ctx);
+		glx_ctx = NULL;
+	}
 	if (win)
 		x11_window_destroy(win);
 #endif

--- a/include/GL/glx.h
+++ b/include/GL/glx.h
@@ -1,0 +1,95 @@
+#ifndef GLX_H
+#define GLX_H
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <GLES/gl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GLX_VERSION_1_1 1
+
+enum _GLX_CONFIGS {
+    GLX_USE_GL = 1,
+    GLX_BUFFER_SIZE,
+    GLX_LEVEL,
+    GLX_RGBA,
+    GLX_DOUBLEBUFFER,
+    GLX_STEREO,
+    GLX_AUX_BUFFERS,
+    GLX_RED_SIZE,
+    GLX_GREEN_SIZE,
+    GLX_BLUE_SIZE,
+    GLX_ALPHA_SIZE,
+    GLX_DEPTH_SIZE,
+    GLX_STENCIL_SIZE,
+    GLX_ACCUM_RED_SIZE,
+    GLX_ACCUM_GREEN_SIZE,
+    GLX_ACCUM_BLUE_SIZE,
+    GLX_ACCUM_ALPHA_SIZE,
+    GLX_X_VISUAL_TYPE_EXT = 0x22,
+    GLX_TRANSPARENT_TYPE_EXT = 0x23,
+    GLX_TRANSPARENT_INDEX_VALUE_EXT = 0x24,
+    GLX_TRANSPARENT_RED_VALUE_EXT = 0x25,
+    GLX_TRANSPARENT_GREEN_VALUE_EXT = 0x26,
+    GLX_TRANSPARENT_BLUE_VALUE_EXT = 0x27,
+    GLX_TRANSPARENT_ALPHA_VALUE_EXT = 0x28
+};
+
+#define GLX_BAD_SCREEN 1
+#define GLX_BAD_ATTRIBUTE 2
+#define GLX_NO_EXTENSION 3
+#define GLX_BAD_VISUAL 4
+#define GLX_BAD_CONTEXT 5
+#define GLX_BAD_VALUE 6
+#define GLX_BAD_ENUM 7
+
+#define GLX_VENDOR 1
+#define GLX_VERSION 2
+#define GLX_EXTENSIONS 3
+
+#define GLX_TRUE_COLOR_EXT 0x8002
+#define GLX_DIRECT_COLOR_EXT 0x8003
+#define GLX_PSEUDO_COLOR_EXT 0x8004
+#define GLX_STATIC_COLOR_EXT 0x8005
+#define GLX_GRAY_SCALE_EXT 0x8006
+#define GLX_STATIC_GRAY_EXT 0x8007
+#define GLX_NONE_EXT 0x8000
+#define GLX_TRANSPARENT_RGB_EXT 0x8008
+#define GLX_TRANSPARENT_INDEX_EXT 0x8009
+
+typedef void *GLXContext;
+typedef Pixmap GLXPixmap;
+typedef Drawable GLXDrawable;
+typedef XID GLXContextID;
+
+XVisualInfo *glXChooseVisual(Display *dpy, int screen, int *attribList);
+GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis,
+                            GLXContext shareList, Bool direct);
+void glXDestroyContext(Display *dpy, GLXContext ctx);
+Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext ctx);
+void glXCopyContext(Display *dpy, GLXContext src, GLXContext dst,
+                    GLuint mask);
+void glXSwapBuffers(Display *dpy, GLXDrawable drawable);
+GLXPixmap glXCreateGLXPixmap(Display *dpy, XVisualInfo *visual, Pixmap pixmap);
+void glXDestroyGLXPixmap(Display *dpy, GLXPixmap pixmap);
+Bool glXQueryExtension(Display *dpy, int *errorb, int *event);
+Bool glXQueryVersion(Display *dpy, int *maj, int *min);
+Bool glXIsDirect(Display *dpy, GLXContext ctx);
+int glXGetConfig(Display *dpy, XVisualInfo *visual, int attrib, int *value);
+GLXContext glXGetCurrentContext(void);
+GLXDrawable glXGetCurrentDrawable(void);
+void glXWaitGL(void);
+void glXWaitX(void);
+void glXUseXFont(Font font, int first, int count, int list);
+const char *glXQueryExtensionsString(Display *dpy, int screen);
+const char *glXQueryServerString(Display *dpy, int screen, int name);
+const char *glXGetClientString(Display *dpy, int name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GLX_H */

--- a/src/glx.c
+++ b/src/glx.c
@@ -1,0 +1,165 @@
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include "x11_window.h"
+#include "gl_init.h"
+#include "gl_utils.h"
+#include <GL/glx.h>
+
+typedef struct uGLESXContext {
+	X11Window *win;
+} uGLESXContext;
+
+static uGLESXContext *current_ctx;
+
+Bool glXQueryExtension(Display *dpy, int *errorb, int *event)
+{
+	(void)dpy;
+	(void)errorb;
+	(void)event;
+	return True;
+}
+
+XVisualInfo *glXChooseVisual(Display *dpy, int screen, int *attribList)
+{
+	(void)attribList;
+	XVisualInfo vinfo;
+	int n;
+	if (!XMatchVisualInfo(dpy, screen, 24, TrueColor, &vinfo))
+		return NULL;
+	return XGetVisualInfo(dpy, VisualIDMask, &vinfo, &n);
+}
+
+GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis,
+			    GLXContext shareList, Bool direct)
+{
+	(void)dpy;
+	(void)vis;
+	(void)shareList;
+	(void)direct;
+	uGLESXContext *ctx = tracked_malloc(sizeof(uGLESXContext));
+	if (!ctx)
+		return NULL;
+	ctx->win = NULL;
+	return (GLXContext)ctx;
+}
+
+void glXDestroyContext(Display *dpy, GLXContext ctx)
+{
+	(void)dpy;
+	uGLESXContext *c = (uGLESXContext *)ctx;
+	tracked_free(c, sizeof(uGLESXContext));
+	if (current_ctx == c)
+		current_ctx = NULL;
+}
+
+Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext ctx)
+{
+	(void)dpy;
+	uGLESXContext *c = (uGLESXContext *)ctx;
+	c->win = (X11Window *)(uintptr_t)drawable;
+	current_ctx = c;
+	return True;
+}
+
+void glXSwapBuffers(Display *dpy, GLXDrawable drawable)
+{
+	(void)dpy;
+	(void)drawable;
+	if (!current_ctx || !current_ctx->win)
+		return;
+	x11_window_show_image(current_ctx->win, GL_get_default_framebuffer());
+}
+
+void glXCopyContext(Display *dpy, GLXContext src, GLXContext dst, GLuint mask)
+{
+	(void)dpy;
+	(void)src;
+	(void)dst;
+	(void)mask;
+}
+
+GLXPixmap glXCreateGLXPixmap(Display *dpy, XVisualInfo *visual, Pixmap pixmap)
+{
+	(void)dpy;
+	(void)visual;
+	return (GLXPixmap)pixmap;
+}
+
+void glXDestroyGLXPixmap(Display *dpy, GLXPixmap pixmap)
+{
+	(void)dpy;
+	(void)pixmap;
+}
+
+Bool glXQueryVersion(Display *dpy, int *maj, int *min)
+{
+	(void)dpy;
+	if (maj)
+		*maj = 1;
+	if (min)
+		*min = 1;
+	return True;
+}
+
+Bool glXIsDirect(Display *dpy, GLXContext ctx)
+{
+	(void)dpy;
+	(void)ctx;
+	return True;
+}
+
+int glXGetConfig(Display *dpy, XVisualInfo *visual, int attrib, int *value)
+{
+	(void)dpy;
+	(void)visual;
+	(void)attrib;
+	(void)value;
+	return 0;
+}
+
+GLXContext glXGetCurrentContext(void)
+{
+	return (GLXContext)current_ctx;
+}
+
+GLXDrawable glXGetCurrentDrawable(void)
+{
+	return current_ctx ? (GLXDrawable)(uintptr_t)current_ctx->win : 0;
+}
+
+void glXWaitGL(void)
+{
+}
+void glXWaitX(void)
+{
+}
+
+void glXUseXFont(Font font, int first, int count, int list)
+{
+	(void)font;
+	(void)first;
+	(void)count;
+	(void)list;
+}
+
+const char *glXQueryExtensionsString(Display *dpy, int screen)
+{
+	(void)dpy;
+	(void)screen;
+	return "";
+}
+
+const char *glXQueryServerString(Display *dpy, int screen, int name)
+{
+	(void)dpy;
+	(void)screen;
+	(void)name;
+	return "";
+}
+
+const char *glXGetClientString(Display *dpy, int name)
+{
+	(void)dpy;
+	(void)name;
+	return "";
+}

--- a/src/matrix_utils.c
+++ b/src/matrix_utils.c
@@ -3,6 +3,7 @@
 #include "matrix_utils.h"
 #include "gl_logger.h" // Ensure logger is initialized before using
 #include "c11_opt.h"
+#include <GLES/gl.h>
 
 /* Define Pi for angle conversions */
 #ifndef M_PI
@@ -529,6 +530,40 @@ void mat4_look_at(mat4 *restrict mat, GLfloat eyeX, GLfloat eyeY, GLfloat eyeZ,
 	mat->data[12] = -sx * eyeX - sy * eyeY - sz * eyeZ;
 	mat->data[13] = -ux * eyeX - uy * eyeY - uz * eyeZ;
 	mat->data[14] = fx * eyeX + fy * eyeY + fz * eyeZ;
+}
+
+/**
+ * @brief Multiplies the current matrix by a lookAt transform, replicating
+ *        classic GLU behaviour.
+ */
+void gluLookAt(GLfloat eyeX, GLfloat eyeY, GLfloat eyeZ, GLfloat centerX,
+	       GLfloat centerY, GLfloat centerZ, GLfloat upX, GLfloat upY,
+	       GLfloat upZ)
+{
+	mat4 look;
+	mat4_look_at(&look, eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX,
+		     upY, upZ);
+	glMultMatrixf(look.data);
+}
+
+/**
+ * @brief Multiplies the current matrix by a perspective projection.
+ */
+void gluPerspective(GLfloat fovy, GLfloat aspect, GLfloat zNear, GLfloat zFar)
+{
+	mat4 proj;
+	mat4_perspective(&proj, fovy, aspect, zNear, zFar);
+	glMultMatrixf(proj.data);
+}
+
+/**
+ * @brief Multiplies the current matrix by a 2D orthographic projection.
+ */
+void gluOrtho2D(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top)
+{
+	mat4 ortho;
+	mat4_orthographic(&ortho, left, right, bottom, top, -1.0f, 1.0f);
+	glMultMatrixf(ortho.data);
 }
 
 /**

--- a/src/matrix_utils.h
+++ b/src/matrix_utils.h
@@ -77,6 +77,13 @@ void mat4_rotate_axis(mat4 *restrict mat, GLfloat angle, GLfloat x, GLfloat y,
 void mat4_look_at(mat4 *restrict mat, GLfloat eyeX, GLfloat eyeY, GLfloat eyeZ,
 		  GLfloat centerX, GLfloat centerY, GLfloat centerZ,
 		  GLfloat upX, GLfloat upY, GLfloat upZ);
+/* GLU-style helper to multiply the current matrix by a look-at transform */
+void gluLookAt(GLfloat eyeX, GLfloat eyeY, GLfloat eyeZ, GLfloat centerX,
+	       GLfloat centerY, GLfloat centerZ, GLfloat upX, GLfloat upY,
+	       GLfloat upZ);
+/* GLU-style projection helpers */
+void gluPerspective(GLfloat fovy, GLfloat aspect, GLfloat zNear, GLfloat zFar);
+void gluOrtho2D(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top);
 void mat4_perspective(mat4 *restrict mat, GLfloat fovy, GLfloat aspect,
 		      GLfloat zNear, GLfloat zFar);
 void mat4_frustum(mat4 *restrict mat, GLfloat left, GLfloat right,


### PR DESCRIPTION
## Summary
- add constants and data structures for random pyramid scene
- implement `init_gl`, `generate_pyramid_geometry` and `render_scene`
- update perf_monitor main loop to render many spinning pyramids
- add minimal GLX wrapper for X11 display output
- rename TinyGLXContext to uGLESXContext

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_685821b1032c832593639da52b55ae50