### PR TITLE
Handle X11 display in GLX context

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -172,8 +172,9 @@ int main(int argc, char **argv)
 	X11Window *win = x11_window_create(1024, 768, "microGLES Perf");
 	GLXContext glx_ctx = NULL;
 	if (win) {
-		glx_ctx = glXCreateContext(NULL, NULL, NULL, False);
-		glXMakeCurrent(NULL, (GLXDrawable)(uintptr_t)win, glx_ctx);
+		Display *dpy = x11_window_get_display(win);
+		glx_ctx = glXCreateContext(dpy, NULL, NULL, False);
+		glXMakeCurrent(dpy, (GLXDrawable)(uintptr_t)win, glx_ctx);
 	}
 #else
 	X11Window *win = NULL;

--- a/src/glx.c
+++ b/src/glx.c
@@ -7,6 +7,7 @@
 
 typedef struct uGLESXContext {
 	X11Window *win;
+	Display *display;
 } uGLESXContext;
 
 static uGLESXContext *current_ctx;
@@ -32,7 +33,6 @@ XVisualInfo *glXChooseVisual(Display *dpy, int screen, int *attribList)
 GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis,
 			    GLXContext shareList, Bool direct)
 {
-	(void)dpy;
 	(void)vis;
 	(void)shareList;
 	(void)direct;
@@ -40,6 +40,7 @@ GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis,
 	if (!ctx)
 		return NULL;
 	ctx->win = NULL;
+	ctx->display = dpy;
 	return (GLXContext)ctx;
 }
 
@@ -57,6 +58,7 @@ Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext ctx)
 	(void)dpy;
 	uGLESXContext *c = (uGLESXContext *)ctx;
 	c->win = (X11Window *)(uintptr_t)drawable;
+	c->display = x11_window_get_display(c->win);
 	current_ctx = c;
 	return True;
 }
@@ -68,6 +70,8 @@ void glXSwapBuffers(Display *dpy, GLXDrawable drawable)
 	if (!current_ctx || !current_ctx->win)
 		return;
 	x11_window_show_image(current_ctx->win, GL_get_default_framebuffer());
+	if (current_ctx->display)
+		XFlush(current_ctx->display);
 }
 
 void glXCopyContext(Display *dpy, GLXContext src, GLXContext dst, GLuint mask)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -85,3 +85,8 @@ void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 		  height);
 	XFlush(w->display);
 }
+
+Display *x11_window_get_display(const X11Window *w)
+{
+	return w ? w->display : NULL;
+}

--- a/src/x11_window.h
+++ b/src/x11_window.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <X11/Xlib.h>
 
 struct Framebuffer;
 
@@ -12,5 +13,6 @@ X11Window *x11_window_create(unsigned width, unsigned height,
 			     const char *title);
 void x11_window_destroy(X11Window *win);
 void x11_window_show_image(X11Window *win, const struct Framebuffer *fb);
+Display *x11_window_get_display(const X11Window *win);
 
 #endif /* X11_WINDOW_H */


### PR DESCRIPTION
## Summary
- expose `x11_window_get_display` to fetch the `Display*`
- track `Display*` inside `uGLESXContext`
- use the stored display when making the context current and when swapping buffers
- pass the X11 display to GLX functions in `perf_monitor`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `ASAN_OPTIONS=halt_on_error=1 ./build_debug/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_68583643bd2c83259af633a96eea4e11