### PR TITLE
Fix x11 image cleanup

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -52,11 +52,8 @@ void x11_window_destroy(X11Window *w)
 {
 	if (!w)
 		return;
-	if (w->image) {
-		free(w->image->data);
-		w->image->data = NULL;
+	if (w->image)
 		XDestroyImage(w->image);
-	}
 	XFreeGC(w->display, w->gc);
 	XDestroyWindow(w->display, w->window);
 	XCloseDisplay(w->display);


### PR DESCRIPTION
## Summary
- let `XDestroyImage` free X11 image memory

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68583732196c8325b9a09ac8b952604b