### PR TITLE
Fix XImage write path

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -73,9 +73,10 @@ void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 			unsigned char *dst = (unsigned char *)w->image->data +
 					     (y * w->image->bytes_per_line) +
 					     x * 4;
-			dst[0] = (pixel >> 16) & 0xFF; // R
+			dst[0] = pixel & 0xFF; // R
 			dst[1] = (pixel >> 8) & 0xFF; // G
-			dst[2] = pixel & 0xFF; // B
+			dst[2] = (pixel >> 16) & 0xFF; // B
+			dst[3] = 0xFF; // alpha
 		}
 	}
 	XPutImage(w->display, w->window, w->gc, w->image, 0, 0, 0, 0, width,


### PR DESCRIPTION
## Summary
- write four bytes per pixel in `x11_window_show_image`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68583b665ba48325ad488c7473cbfcdb