### PR TITLE
Fix perf_monitor rendering

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -205,6 +205,7 @@ int main(int argc, char **argv)
 		double polys = 0.0, pix = 0.0;
 		do {
 			render_scene();
+			glFinish();
 			for (int i = 0; i < NUM_PYRAMIDS; ++i) {
 				pyramids[i].rotation.x +=
 					pyramids[i].rotationSpeed.x * 0.016f;


### PR DESCRIPTION
## Summary
- flush draw commands in perf_monitor so the framebuffer updates the X11 window

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_685840dcac508325b903e5d12543db28