### PR TITLE
Add detailed logging for X11 setup

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -190,11 +190,27 @@ int main(int argc, char **argv)
 	}
 #ifdef HAVE_X11
 	X11Window *win = x11_window_create(1024, 768, "microGLES Perf");
+	if (!win) {
+		LOG_ERROR("x11_window_create failed. DISPLAY=%s",
+			  getenv("DISPLAY"));
+	} else {
+		LOG_INFO("x11_window_create succeeded");
+	}
 	GLXContext glx_ctx = NULL;
 	if (win) {
 		Display *dpy = x11_window_get_display(win);
 		glx_ctx = glXCreateContext(dpy, NULL, NULL, False);
-		glXMakeCurrent(dpy, (GLXDrawable)(uintptr_t)win, glx_ctx);
+		if (glx_ctx) {
+			LOG_INFO("glXCreateContext succeeded");
+		} else {
+			LOG_ERROR("glXCreateContext failed");
+		}
+		if (glx_ctx &&
+		    glXMakeCurrent(dpy, (GLXDrawable)(uintptr_t)win, glx_ctx)) {
+			LOG_INFO("glXMakeCurrent succeeded");
+		} else if (glx_ctx) {
+			LOG_ERROR("glXMakeCurrent failed");
+		}
 	}
 #else
 	X11Window *win = NULL;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1,5 +1,6 @@
 #include "x11_window.h"
 #include "pipeline/gl_framebuffer.h"
+#include "gl_logger.h"
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <stdlib.h>
@@ -20,8 +21,10 @@ struct X11Window {
 X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 {
 	Display *dpy = XOpenDisplay(NULL);
-	if (!dpy)
+	if (!dpy) {
+		LOG_ERROR("XOpenDisplay failed. DISPLAY=%s", getenv("DISPLAY"));
 		return NULL;
+	}
 	int screen = DefaultScreen(dpy);
 	Window win = XCreateSimpleWindow(dpy, RootWindow(dpy, screen), 0, 0,
 					 width, height, 0,
@@ -45,6 +48,7 @@ X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 				malloc(width * height * 4), width, height, 32,
 				0);
 	if (!w->image) {
+		LOG_ERROR("XCreateImage failed");
 		free(w);
 		return NULL;
 	}
@@ -119,10 +123,9 @@ bool x11_window_has_non_monochrome(const X11Window *w)
 		return false;
 	bool non_white = false;
 	bool non_black = false;
-	for (unsigned y = 0; y < img->height && !(non_white && non_black);
-	     ++y) {
-		for (unsigned x = 0; x < img->width; ++x) {
-			unsigned long p = XGetPixel(img, (int)x, (int)y);
+	for (int y = 0; y < img->height && !(non_white && non_black); ++y) {
+		for (int x = 0; x < img->width; ++x) {
+			unsigned long p = XGetPixel(img, x, y);
 			unsigned int rgb = ((p >> 16) & 0xFF) << 16 |
 					   ((p >> 8) & 0xFF) << 8 | (p & 0xFF);
 			if (rgb != 0xFFFFFFu)


### PR DESCRIPTION
## Summary
- record failures creating X11 windows
- show results of glX context setup in perf_monitor
- fix signedness warnings in `x11_window_has_non_monochrome`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_68585555ca1c8325962f1f557bf988de