### PR TITLE
Add profile flag and threads note to perf_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cmake --build build
 Set `MICROGLES_THREADS` to specify the number of worker threads (defaults to the
 number of online CPUs).
 
-To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required.
+To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count.
 
 ### Debug / Sanitizer
 

--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -164,10 +164,26 @@ static bool check_fb_content(const Framebuffer *fb)
 	return has_non_white && has_non_black;
 }
 
+static void usage(const char *prog)
+{
+	printf("Usage: %s [--profile]\n", prog);
+	printf("Set MICROGLES_THREADS to control worker thread count.\n");
+}
+
 int main(int argc, char **argv)
 {
-	(void)argc;
-	(void)argv;
+	bool profile = false;
+	for (int i = 1; i < argc; ++i) {
+		if (strcmp(argv[i], "--profile") == 0) {
+			profile = true;
+		} else if (strcmp(argv[i], "--help") == 0) {
+			usage(argv[0]);
+			return 0;
+		} else {
+			usage(argv[0]);
+			return 1;
+		}
+	}
 	if (!logger_init("perf_monitor.log", LOG_LEVEL_INFO)) {
 		fprintf(stderr, "Failed to initialize logger.\n");
 		return -1;
@@ -181,7 +197,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 	command_buffer_init();
-	thread_profile_start();
+	if (profile)
+		thread_profile_start();
 	InitGLState(&gl_state);
 	Framebuffer *fb = GL_init_with_framebuffer(1024, 768);
 	if (!fb) {
@@ -312,7 +329,8 @@ int main(int argc, char **argv)
 		LOG_INFO("Second %d summary: %.2f MP/s polys, %.2f MP/s pixels",
 			 sec + 1, polys / wall / 1e6, pix / wall / 1e6);
 		thread_realtime_report();
-		thread_profile_start();
+		if (profile)
+			thread_profile_start();
 	}
 #ifdef HAVE_X11
 	if (glx_ctx) {


### PR DESCRIPTION
## Summary
- add `--profile` option to perf_monitor
- document `MICROGLES_THREADS` in perf_monitor help and README

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68585c9f81788325bcd438b4d24129e1