### PR TITLE
Improve perf_monitor logging

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -166,9 +166,24 @@ static bool check_fb_content(const Framebuffer *fb)
 
 int main(int argc, char **argv)
 {
-	(void)argc;
-	(void)argv;
-	if (!logger_init("perf_monitor.log", LOG_LEVEL_INFO)) {
+	LogLevel log_level = LOG_LEVEL_INFO;
+	for (int i = 1; i < argc; ++i) {
+		const char *arg = argv[i];
+		if (strncmp(arg, "--log-level=", 12) == 0) {
+			const char *lvl = arg + 12;
+			if (strcmp(lvl, "debug") == 0)
+				log_level = LOG_LEVEL_DEBUG;
+			else if (strcmp(lvl, "info") == 0)
+				log_level = LOG_LEVEL_INFO;
+			else if (strcmp(lvl, "warn") == 0)
+				log_level = LOG_LEVEL_WARN;
+			else if (strcmp(lvl, "error") == 0)
+				log_level = LOG_LEVEL_ERROR;
+			else if (strcmp(lvl, "fatal") == 0)
+				log_level = LOG_LEVEL_FATAL;
+		}
+	}
+	if (!logger_init("perf_monitor.log", log_level)) {
 		fprintf(stderr, "Failed to initialize logger.\n");
 		return -1;
 	}
@@ -262,8 +277,13 @@ int main(int argc, char **argv)
 		cstart = thread_get_cycles();
 		double polys = 0.0, pix = 0.0;
 		do {
+			LOG_DEBUG("before render_scene");
 			render_scene();
+			LOG_DEBUG("after render_scene");
+
+			LOG_DEBUG("before glFinish");
 			glFinish();
+			LOG_DEBUG("after glFinish");
 			for (int i = 0; i < NUM_PYRAMIDS; ++i) {
 				pyramids[i].rotation.x +=
 					pyramids[i].rotationSpeed.x * 0.016f;
@@ -274,13 +294,18 @@ int main(int argc, char **argv)
 			}
 			polys += NUM_PYRAMIDS * 6.0f;
 			pix += NUM_PYRAMIDS * 6.0f * face_pixels;
+			LOG_DEBUG("before thread_pool_wait");
 			thread_pool_wait();
+			LOG_DEBUG("after thread_pool_wait");
 #ifdef HAVE_X11
-			if (win)
+			if (win) {
+				LOG_DEBUG("before glXSwapBuffers");
 				glXSwapBuffers(dpy,
 					       (GLXDrawable)(uintptr_t)win);
+				LOG_DEBUG("after glXSwapBuffers");
+			}
 #endif
-			if (frame_idx < 2) {
+			{
 				bool fb_ok = check_fb_content(fb);
 #ifdef HAVE_X11
 				bool win_ok =
@@ -288,6 +313,9 @@ int main(int argc, char **argv)
 #else
 				bool win_ok = fb_ok;
 #endif
+				LOG_INFO("Framebuffer frame %d %s (window %s)",
+					 frame_idx + 1, fb_ok ? "PASS" : "FAIL",
+					 win_ok ? "PASS" : "FAIL");
 				printf("Framebuffer frame %d %s (window %s)\n",
 				       frame_idx + 1, fb_ok ? "PASS" : "FAIL",
 				       win_ok ? "PASS" : "FAIL");


### PR DESCRIPTION
## Summary
- make log level configurable with `--log-level=` in perf_monitor
- add debug logs around render loop operations
- report framebuffer results every frame

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build/bin/benchmark` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68585c8edca48325b26d9dd7c77b7e41