### PR TITLE
Fix perf_monitor profiling option

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -19,6 +19,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <stdlib.h>
+#include <stdbool.h>
 /* Pyramid benchmark parameters */
 #define SCREEN_WIDTH 1024
 #define SCREEN_HEIGHT 768
@@ -173,9 +174,12 @@ static void usage(const char *prog)
 int main(int argc, char **argv)
 {
 	LogLevel log_level = LOG_LEVEL_INFO;
+	bool profile = false;
 	for (int i = 1; i < argc; ++i) {
 		const char *arg = argv[i];
-		if (strncmp(arg, "--log-level=", 12) == 0) {
+		if (strcmp(arg, "--profile") == 0) {
+			profile = true;
+		} else if (strncmp(arg, "--log-level=", 12) == 0) {
 			const char *lvl = arg + 12;
 			if (strcmp(lvl, "debug") == 0)
 				log_level = LOG_LEVEL_DEBUG;


### PR DESCRIPTION
## Summary
- include `<stdbool.h>` in `perf_monitor.c`
- parse the `--profile` flag so thread profiling starts when requested

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cd build && ctest --output-on-failure`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_68585fce9550832590ba39dfb078d466