### PR TITLE
Handle GL_FOG_MODE validation

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -173,8 +173,13 @@ static void usage(const char *prog)
 int main(int argc, char **argv)
 {
 	LogLevel log_level = LOG_LEVEL_INFO;
+	bool profile = false;
 	for (int i = 1; i < argc; ++i) {
 		const char *arg = argv[i];
+		if (strcmp(arg, "--profile") == 0) {
+			profile = true;
+			continue;
+		}
 		if (strncmp(arg, "--log-level=", 12) == 0) {
 			const char *lvl = arg + 12;
 			if (strcmp(lvl, "debug") == 0)

--- a/src/gl_api_misc.c
+++ b/src/gl_api_misc.c
@@ -81,9 +81,17 @@ GL_API void GL_APIENTRY glFogfv(GLenum pname, const GLfloat *params)
 		gl_state.fog_end = params[0];
 		context_set_fog(pname, params);
 		break;
-	case GL_FOG_MODE:
-		gl_state.fog_mode = (GLenum)params[0];
+	case GL_FOG_MODE: {
+		GLenum mode = (GLenum)params[0];
+		if (mode != GL_LINEAR && mode != GL_EXP && mode != GL_EXP2) {
+			glSetError(GL_INVALID_ENUM);
+			return;
+		}
+		gl_state.fog_mode = mode;
+		GLfloat tmp[4] = { (GLfloat)mode, 0.0f, 0.0f, 0.0f };
+		context_set_fog(pname, tmp);
 		break;
+	}
 	default:
 		glSetError(GL_INVALID_ENUM);
 		break;


### PR DESCRIPTION
## Summary
- validate fog mode values in `glFogfv`
- fix missing `profile` flag handling in `perf_monitor`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68585fdbf3cc8325bcc6241afed96353