### PR TITLE
Validate GL_FOG_MODE enum

### DIFF
--- a/src/gl_api_misc.c
+++ b/src/gl_api_misc.c
@@ -81,9 +81,17 @@ GL_API void GL_APIENTRY glFogfv(GLenum pname, const GLfloat *params)
 		gl_state.fog_end = params[0];
 		context_set_fog(pname, params);
 		break;
-	case GL_FOG_MODE:
-		gl_state.fog_mode = (GLenum)params[0];
+	case GL_FOG_MODE: {
+		GLenum mode = (GLenum)(int)params[0];
+		if (mode != GL_LINEAR && mode != GL_EXP && mode != GL_EXP2) {
+			glSetError(GL_INVALID_ENUM);
+			break;
+		}
+		gl_state.fog_mode = mode;
+		GLfloat mval = (GLfloat)mode;
+		context_set_fog(pname, &mval);
 		break;
+	}
 	default:
 		glSetError(GL_INVALID_ENUM);
 		break;


### PR DESCRIPTION
## Summary
- validate GL_FOG_MODE enum value
- update fog state in context when valid

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_685861910ac48325937bb2e59298285a