### PR TITLE
Fix milestone2 benchmark result reporting

### DIFF
--- a/benchmark/src/milestone2.c
+++ b/benchmark/src/milestone2.c
@@ -166,6 +166,7 @@ void run_milestone2(Framebuffer *fb, BenchmarkResult *result)
 	glBindFramebufferOES(GL_FRAMEBUFFER_OES, 0);
 	CHECK_ERROR();
 
+	clock_t start = clock();
 	glDrawTexiOES(100, 100, 0, 32, 32);
 	glDrawTexfvOES((GLfloat[]){ 100, 100, 0, 32, 32 });
 	CHECK_ERROR();
@@ -199,6 +200,9 @@ void run_milestone2(Framebuffer *fb, BenchmarkResult *result)
 	uint32_t pixel = framebuffer_get_pixel(fb, 160, 160);
 	LogMessage(LOG_LEVEL_INFO, "Center pixel: 0x%08X", pixel);
 
-	(void)fb;
-	(void)result;
+	thread_pool_wait();
+	clock_t end = clock();
+	compute_result(start, end, result);
+	LOG_INFO("milestone2: %.2f FPS, %.2f ms/frame", result->fps,
+		 result->cpu_time_ms);
 }

--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -172,9 +172,14 @@ static void usage(const char *prog)
 
 int main(int argc, char **argv)
 {
+	bool profile = false;
 	LogLevel log_level = LOG_LEVEL_INFO;
 	for (int i = 1; i < argc; ++i) {
 		const char *arg = argv[i];
+		if (strcmp(arg, "--profile") == 0) {
+			profile = true;
+			continue;
+		}
 		if (strncmp(arg, "--log-level=", 12) == 0) {
 			const char *lvl = arg + 12;
 			if (strcmp(lvl, "debug") == 0)


### PR DESCRIPTION
## Summary
- log FPS for milestone2 like other benchmarks
- parse `--profile` flag in perf_monitor

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `build/bin/renderer_conformance`
- `timeout 10s build/bin/benchmark` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68585fe610548325a2acaa8476eaa313