### PR TITLE
Ensure milestone2 waits for tasks and records results

### DIFF
--- a/benchmark/src/milestone2.c
+++ b/benchmark/src/milestone2.c
@@ -166,6 +166,8 @@ void run_milestone2(Framebuffer *fb, BenchmarkResult *result)
 	glBindFramebufferOES(GL_FRAMEBUFFER_OES, 0);
 	CHECK_ERROR();
 
+	clock_t start = clock();
+
 	glDrawTexiOES(100, 100, 0, 32, 32);
 	glDrawTexfvOES((GLfloat[]){ 100, 100, 0, 32, 32 });
 	CHECK_ERROR();
@@ -198,6 +200,12 @@ void run_milestone2(Framebuffer *fb, BenchmarkResult *result)
 
 	uint32_t pixel = framebuffer_get_pixel(fb, 160, 160);
 	LogMessage(LOG_LEVEL_INFO, "Center pixel: 0x%08X", pixel);
+
+	thread_pool_wait();
+	clock_t end = clock();
+	compute_result(start, end, result);
+	LogMessage(LOG_LEVEL_INFO, "milestone2: %.2f FPS, %.2f ms/frame",
+		   result->fps, result->cpu_time_ms);
 
 	(void)fb;
 	(void)result;


### PR DESCRIPTION
## Summary
- sync queued GL commands in `milestone2` to avoid dangling tasks
- time the draw calls and report FPS/cpu time like other benchmarks

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake --build build --target format`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark` *(no output)*
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6858628684988325ae1271d488880038