### PR TITLE
Improve X11 threading and GLX stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,4 @@ Pull requests that break conformance or style are rejected automatically.
 ## License
 
 MIT — see [`LICENSE`](LICENSE).
+\nMinor internal improvements to X11 and GLX

--- a/src/gl_context.c
+++ b/src/gl_context.c
@@ -207,6 +207,11 @@ void context_init(void)
 	LOG_INFO("Render context initialized");
 }
 
+void context_cleanup(void)
+{
+	LOG_INFO("Render context cleanup");
+}
+
 RenderContext *context_get(void)
 {
 	return &g_render_context;

--- a/src/gl_context.h
+++ b/src/gl_context.h
@@ -167,6 +167,7 @@ typedef struct {
 } RenderContext;
 
 void context_init(void);
+void context_cleanup(void);
 RenderContext *context_get(void);
 RenderContext *GetCurrentContext(void);
 void context_update_modelview_matrix(const mat4 *mat);

--- a/src/gl_init.c
+++ b/src/gl_init.c
@@ -14,154 +14,168 @@ static pthread_mutex_t g_fb_mutex = PTHREAD_MUTEX_INITIALIZER;
 // Initializes OpenGL ES with default state.
 void GL_init(void)
 {
-    glSetError(GL_NO_ERROR);
-    context_init(); // Initialize context (assumed to set up gl_state)
-    GL_resetState();
-    GL_setupViewport(0, 0, 800, 600); // Default viewport
-    GL_defaultMatrixSetup();
-    LOG_INFO("OpenGL ES initialized with default state.");
+	glSetError(GL_NO_ERROR);
+	context_init(); // Initialize context (assumed to set up gl_state)
+	GL_resetState();
+	GL_setupViewport(0, 0, 800, 600); // Default viewport
+	GL_defaultMatrixSetup();
+	LOG_INFO("OpenGL ES initialized with default state.");
 }
 
 // Cleans up OpenGL ES context and resources.
 void GL_cleanup(void)
 {
-    context_cleanup(); // Assumed to clean up gl_state
-    LOG_INFO("OpenGL ES cleanup completed.");
+	context_cleanup(); // Assumed to clean up gl_state
+	LOG_INFO("OpenGL ES cleanup completed.");
 }
 
 // Sets up the viewport and adjusts the projection matrix.
 void GL_setupViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
-    if (width <= 0 || height <= 0) {
-        glSetError(GL_INVALID_VALUE);
-        LOG_ERROR("Invalid viewport dimensions: width=%d, height=%d", width, height);
-        return;
-    }
+	if (width <= 0 || height <= 0) {
+		glSetError(GL_INVALID_VALUE);
+		LOG_ERROR("Invalid viewport dimensions: width=%d, height=%d",
+			  width, height);
+		return;
+	}
 
-    glViewport(x, y, width, height);
+	glViewport(x, y, width, height);
 
-    // Set up an orthographic projection
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrthof(0.0f, (GLfloat)width, 0.0f, (GLfloat)height, -1.0f, 1.0f);
+	// Set up an orthographic projection
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrthof(0.0f, (GLfloat)width, 0.0f, (GLfloat)height, -1.0f, 1.0f);
 
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
 
-    LOG_DEBUG("Viewport set: x=%d, y=%d, width=%d, height=%d", x, y, width, height);
+	LOG_DEBUG("Viewport set: x=%d, y=%d, width=%d, height=%d", x, y, width,
+		  height);
 }
 
 // Resets all OpenGL ES states to their default values.
 void GL_resetState(void)
 {
-    // Blending
-    glDisable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // More common default
+	// Blending
+	glDisable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA,
+		    GL_ONE_MINUS_SRC_ALPHA); // More common default
 
-    // Depth
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LESS);
-    glDepthMask(GL_TRUE);
+	// Depth
+	glEnable(GL_DEPTH_TEST);
+	glDepthFunc(GL_LESS);
+	glDepthMask(GL_TRUE);
 
-    // Clear values
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClearDepthf(1.0f);
+	// Clear values
+	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+	glClearDepthf(1.0f);
 
-    // Textures
-    glDisable(GL_TEXTURE_2D);
-    glActiveTexture(GL_TEXTURE0);
+	// Textures
+	glDisable(GL_TEXTURE_2D);
+	glActiveTexture(GL_TEXTURE0);
 
-    // Culling
-    glDisable(GL_CULL_FACE);
-    glCullFace(GL_BACK);
-    glFrontFace(GL_CCW);
+	// Culling
+	glDisable(GL_CULL_FACE);
+	glCullFace(GL_BACK);
+	glFrontFace(GL_CCW);
 
-    // Stencil
-    glDisable(GL_STENCIL_TEST);
-    glStencilMask(~0U);
+	// Stencil
+	glDisable(GL_STENCIL_TEST);
+	glStencilMask(~0U);
 
-    // Point size
-    glPointSize(1.0f);
+	// Point size
+	glPointSize(1.0f);
 
-    LOG_DEBUG("OpenGL ES state reset to defaults.");
+	LOG_DEBUG("OpenGL ES state reset to defaults.");
 }
 
 // Sets up default matrices for projection and modelview.
 void GL_defaultMatrixSetup(void)
 {
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
 
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
 
-    glDepthRangef(0.0f, 1.0f);
+	glDepthRangef(0.0f, 1.0f);
 
-    LOG_DEBUG("Default matrix setup completed.");
+	LOG_DEBUG("Default matrix setup completed.");
 }
 
 // Initializes OpenGL ES with a framebuffer.
 Framebuffer *GL_init_with_framebuffer(uint32_t width, uint32_t height)
 {
-    if (width == 0 || height == 0 || width > 16384 || height > 16384) {
-        glSetError(GL_INVALID_VALUE);
-        LOG_ERROR("Invalid framebuffer dimensions: %ux%u", width, height);
-        return NULL;
-    }
+	if (width == 0 || height == 0 || width > 16384 || height > 16384) {
+		glSetError(GL_INVALID_VALUE);
+		LOG_ERROR("Invalid framebuffer dimensions: %ux%u", width,
+			  height);
+		return NULL;
+	}
 
-    glSetError(GL_NO_ERROR);
-    context_init();
-    GL_resetState();
-    GL_setupViewport(0, 0, (GLsizei)width, (GLsizei)height);
-    GL_defaultMatrixSetup();
+	glSetError(GL_NO_ERROR);
+	context_init();
+	GL_resetState();
+	GL_setupViewport(0, 0, (GLsizei)width, (GLsizei)height);
+	GL_defaultMatrixSetup();
 
-    Framebuffer *fb = framebuffer_create(width, height);
-    if (!fb) {
-        glSetError(GL_OUT_OF_MEMORY);
-        LOG_FATAL("Failed to create framebuffer %ux%u", width, height);
-        context_cleanup();
-        return NULL;
-    }
+	Framebuffer *fb = framebuffer_create(width, height);
+	if (!fb) {
+		glSetError(GL_OUT_OF_MEMORY);
+		LOG_FATAL("Failed to create framebuffer %ux%u", width, height);
+		context_cleanup();
+		return NULL;
+	}
 
-    framebuffer_clear(fb, 0x00000000u, 1.0f, 0);
+	framebuffer_clear(fb, 0x00000000u, 1.0f, 0);
 
-    pthread_mutex_lock(&g_fb_mutex);
-    if (g_default_fb) {
-        LOG_WARN("Overwriting existing default framebuffer");
-        framebuffer_destroy(g_default_fb);
-    }
-    g_default_fb = fb;
-    gl_state.default_framebuffer.fb = fb;
-    gl_state.bound_framebuffer = &gl_state.default_framebuffer;
-    pthread_mutex_unlock(&g_fb_mutex);
+	pthread_mutex_lock(&g_fb_mutex);
+	if (g_default_fb) {
+		LOG_WARN("Overwriting existing default framebuffer");
+		framebuffer_destroy(g_default_fb);
+	}
+	g_default_fb = fb;
+	gl_state.default_framebuffer.fb = fb;
+	gl_state.bound_framebuffer = &gl_state.default_framebuffer;
+	pthread_mutex_unlock(&g_fb_mutex);
 
-    LOG_INFO("Initialized renderer with framebuffer %ux%u", width, height);
-    return fb;
+	LOG_INFO("Initialized renderer with framebuffer %ux%u", width, height);
+	return fb;
 }
 
 // Cleans up the framebuffer and OpenGL ES context.
 void GL_cleanup_with_framebuffer(Framebuffer *fb)
 {
-    pthread_mutex_lock(&g_fb_mutex);
-    if (fb && fb == g_default_fb) {
-        framebuffer_destroy(fb);
-        g_default_fb = NULL;
-        gl_state.default_framebuffer.fb = NULL;
-        gl_state.bound_framebuffer = NULL;
-        LOG_INFO("Destroyed default framebuffer");
-    } else if (fb) {
-        framebuffer_destroy(fb);
-        LOG_INFO("Destroyed non-default framebuffer");
-    }
-    pthread_mutex_unlock(&g_fb_mutex);
-    GL_cleanup();
+	pthread_mutex_lock(&g_fb_mutex);
+	if (fb && fb == g_default_fb) {
+		framebuffer_destroy(fb);
+		g_default_fb = NULL;
+		gl_state.default_framebuffer.fb = NULL;
+		gl_state.bound_framebuffer = NULL;
+		LOG_INFO("Destroyed default framebuffer");
+	} else if (fb) {
+		framebuffer_destroy(fb);
+		LOG_INFO("Destroyed non-default framebuffer");
+	}
+	pthread_mutex_unlock(&g_fb_mutex);
+	GL_cleanup();
 }
 
 // Returns the default framebuffer.
 Framebuffer *GL_get_default_framebuffer(void)
 {
-    pthread_mutex_lock(&g_fb_mutex);
-    Framebuffer *fb = g_default_fb;
-    pthread_mutex_unlock(&g_fb_mutex);
-    return fb;
+	pthread_mutex_lock(&g_fb_mutex);
+	Framebuffer *fb = g_default_fb;
+	pthread_mutex_unlock(&g_fb_mutex);
+	return fb;
+}
+
+void GL_swap_buffers(void)
+{
+	glFlush();
+}
+
+void GL_finish(void)
+{
+	glFinish();
 }

--- a/src/gl_init.h
+++ b/src/gl_init.h
@@ -34,5 +34,7 @@ void GL_cleanup_with_framebuffer(Framebuffer *fb);
 
 // Retrieve the framebuffer created by GL_init_with_framebuffer
 Framebuffer *GL_get_default_framebuffer(void);
+void GL_swap_buffers(void);
+void GL_finish(void);
 
 #endif // GL_INIT_H

--- a/src/glx.c
+++ b/src/glx.c
@@ -3,13 +3,14 @@
 #include "x11_window.h"
 #include "gl_init.h"
 #include "gl_utils.h"
+#include "gl_logger.h"
 #include <GL/glx.h>
 #include <pthread.h>
 
 typedef struct uGLESXContext {
-    X11Window *win;
-    Display *display;
-    Bool double_buffered;
+	X11Window *win;
+	Display *display;
+	Bool double_buffered;
 } uGLESXContext;
 
 static uGLESXContext *current_ctx = NULL;
@@ -17,272 +18,275 @@ static pthread_mutex_t ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 Bool glXQueryExtension(Display *dpy, int *errorb, int *event)
 {
-    (void)dpy;
-    (void)errorb;
-    (void)event;
-    return True;
+	(void)dpy;
+	(void)errorb;
+	(void)event;
+	return True;
 }
 
 XVisualInfo *glXChooseVisual(Display *dpy, int screen, int *attribList)
 {
-    XVisualInfo vinfo;
-    int n;
-    int depth = 24;
-    int class = TrueColor;
-    Bool double_buffer = False;
+	XVisualInfo vinfo;
+	int n;
+	int depth = 24;
+	int class = TrueColor;
 
-    if (attribList) {
-        for (int *attr = attribList; *attr; attr++) {
-            switch (*attr) {
-                case GLX_RGBA:
-                    class = TrueColor;
-                    break;
-                case GLX_DEPTH_SIZE:
-                    attr++;
-                    depth = *attr;
-                    break;
-                case GLX_DOUBLEBUFFER:
-                    double_buffer = True;
-                    break;
-                case None:
-                    break;
-            }
-        }
-    }
+	if (attribList) {
+		for (int *attr = attribList; *attr; attr++) {
+			switch (*attr) {
+			case GLX_RGBA:
+				class = TrueColor;
+				break;
+			case GLX_DEPTH_SIZE:
+				attr++;
+				depth = *attr;
+				break;
+			case GLX_DOUBLEBUFFER:
+				/* double buffering unsupported */
+				break;
+			case None:
+				break;
+			}
+		}
+	}
 
-    if (!XMatchVisualInfo(dpy, screen, depth, class, &vinfo)) {
-        LOG_ERROR("No matching visual for depth=%d, class=%d", depth, class);
-        return NULL;
-    }
+	if (!XMatchVisualInfo(dpy, screen, depth, class, &vinfo)) {
+		LOG_ERROR("No matching visual for depth=%d, class=%d", depth,
+			  class);
+		return NULL;
+	}
 
-    XVisualInfo *ret = XGetVisualInfo(dpy, VisualIDMask, &vinfo, &n);
-    if (!ret) {
-        LOG_ERROR("XGetVisualInfo failed");
-    }
-    return ret;
+	XVisualInfo *ret = XGetVisualInfo(dpy, VisualIDMask, &vinfo, &n);
+	if (!ret) {
+		LOG_ERROR("XGetVisualInfo failed");
+	}
+	return ret;
 }
 
-GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis, GLXContext shareList, Bool direct)
+GLXContext glXCreateContext(Display *dpy, XVisualInfo *vis,
+			    GLXContext shareList, Bool direct)
 {
-    (void)vis;
-    (void)shareList;
-    (void)direct;
-    if (!dpy) {
-        LOG_ERROR("glXCreateContext: NULL display");
-        return NULL;
-    }
+	(void)vis;
+	(void)shareList;
+	(void)direct;
+	if (!dpy) {
+		LOG_ERROR("glXCreateContext: NULL display");
+		return NULL;
+	}
 
-    uGLESXContext *ctx = tracked_malloc(sizeof(uGLESXContext));
-    if (!ctx) {
-        LOG_ERROR("glXCreateContext: Failed to allocate context");
-        return NULL;
-    }
+	uGLESXContext *ctx = tracked_malloc(sizeof(uGLESXContext));
+	if (!ctx) {
+		LOG_ERROR("glXCreateContext: Failed to allocate context");
+		return NULL;
+	}
 
-    ctx->win = NULL;
-    ctx->display = dpy;
-    ctx->double_buffered = False; // Set based on attribList or config
-    LOG_DEBUG("Created GLX context %p", ctx);
-    return (GLXContext)ctx;
+	ctx->win = NULL;
+	ctx->display = dpy;
+	ctx->double_buffered = False; // Set based on attribList or config
+	LOG_DEBUG("Created GLX context %p", ctx);
+	return (GLXContext)ctx;
 }
 
 void glXDestroyContext(Display *dpy, GLXContext ctx)
 {
-    (void)dpy;
-    if (!ctx) {
-        return;
-    }
+	(void)dpy;
+	if (!ctx) {
+		return;
+	}
 
-    pthread_mutex_lock(&ctx_mutex);
-    uGLESXContext *c = (uGLESXContext *)ctx;
-    if (c == current_ctx) {
-        current_ctx = NULL;
-    }
-    tracked_free(c, sizeof(uGLESXContext));
-    pthread_mutex_unlock(&ctx_mutex);
-    LOG_DEBUG("Destroyed GLX context %p", ctx);
+	pthread_mutex_lock(&ctx_mutex);
+	uGLESXContext *c = (uGLESXContext *)ctx;
+	if (c == current_ctx) {
+		current_ctx = NULL;
+	}
+	tracked_free(c, sizeof(uGLESXContext));
+	pthread_mutex_unlock(&ctx_mutex);
+	LOG_DEBUG("Destroyed GLX context %p", ctx);
 }
 
 Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext ctx)
 {
-    (void)dpy;
-    uGLESXContext *c = (uGLESXContext *)ctx;
-    if (!c || !drawable) {
-        LOG_ERROR("glXMakeCurrent: Invalid context or drawable");
-        return False;
-    }
+	(void)dpy;
+	uGLESXContext *c = (uGLESXContext *)ctx;
+	if (!c || !drawable) {
+		LOG_ERROR("glXMakeCurrent: Invalid context or drawable");
+		return False;
+	}
 
-    c->win = (X11Window *)(uintptr_t)drawable;
-    c->display = x11_window_get_display(c->win);
-    if (!c->display) {
-        LOG_ERROR("glXMakeCurrent: Invalid X11Window drawable");
-        return False;
-    }
+	c->win = (X11Window *)(uintptr_t)drawable;
+	c->display = x11_window_get_display(c->win);
+	if (!c->display) {
+		LOG_ERROR("glXMakeCurrent: Invalid X11Window drawable");
+		return False;
+	}
 
-    pthread_mutex_lock(&ctx_mutex);
-    current_ctx = c;
-    pthread_mutex_unlock(&ctx_mutex);
-    LOG_DEBUG("Made context %p current on drawable %p", ctx, (void *)drawable);
-    return True;
+	pthread_mutex_lock(&ctx_mutex);
+	current_ctx = c;
+	pthread_mutex_unlock(&ctx_mutex);
+	LOG_DEBUG("Made context %p current on drawable %p", ctx,
+		  (void *)drawable);
+	return True;
 }
 
 void glXSwapBuffers(Display *dpy, GLXDrawable drawable)
 {
-    (void)dpy;
-    (void)drawable;
-    pthread_mutex_lock(&ctx_mutex);
-    if (!current_ctx || !current_ctx->win || !current_ctx->display) {
-        LOG_ERROR("glXSwapBuffers: No current context or window");
-        pthread_mutex_unlock(&ctx_mutex);
-        return;
-    }
+	(void)dpy;
+	(void)drawable;
+	pthread_mutex_lock(&ctx_mutex);
+	if (!current_ctx || !current_ctx->win || !current_ctx->display) {
+		LOG_ERROR("glXSwapBuffers: No current context or window");
+		pthread_mutex_unlock(&ctx_mutex);
+		return;
+	}
 
-    Framebuffer *fb = GL_get_default_framebuffer();
-    if (!fb) {
-        LOG_ERROR("glXSwapBuffers: No default framebuffer");
-        pthread_mutex_unlock(&ctx_mutex);
-        return;
-    }
+	Framebuffer *fb = GL_get_default_framebuffer();
+	if (!fb) {
+		LOG_ERROR("glXSwapBuffers: No default framebuffer");
+		pthread_mutex_unlock(&ctx_mutex);
+		return;
+	}
 
-    if (current_ctx->double_buffered) {
-        // Assume GL_swap_buffers exists in gl_init.h
-        GL_swap_buffers();
-    }
+	if (current_ctx->double_buffered) {
+		// Assume GL_swap_buffers exists in gl_init.h
+		GL_swap_buffers();
+	}
 
-    x11_window_show_image(current_ctx->win, fb);
-    pthread_mutex_unlock(&ctx_mutex);
+	x11_window_show_image(current_ctx->win, fb);
+	pthread_mutex_unlock(&ctx_mutex);
 }
 
 void glXCopyContext(Display *dpy, GLXContext src, GLXContext dst, GLuint mask)
 {
-    (void)dpy;
-    (void)src;
-    (void)dst;
-    (void)mask;
-    LOG_WARN("glXCopyContext: Not implemented");
+	(void)dpy;
+	(void)src;
+	(void)dst;
+	(void)mask;
+	LOG_WARN("glXCopyContext: Not implemented");
 }
 
 GLXPixmap glXCreateGLXPixmap(Display *dpy, XVisualInfo *visual, Pixmap pixmap)
 {
-    (void)dpy;
-    (void)visual;
-    LOG_DEBUG("glXCreateGLXPixmap: Returning pixmap %lu", pixmap);
-    return (GLXPixmap)pixmap;
+	(void)dpy;
+	(void)visual;
+	LOG_DEBUG("glXCreateGLXPixmap: Returning pixmap %lu", pixmap);
+	return (GLXPixmap)pixmap;
 }
 
 void glXDestroyGLXPixmap(Display *dpy, GLXPixmap pixmap)
 {
-    (void)dpy;
-    (void)pixmap;
-    LOG_DEBUG("glXDestroyGLXPixmap: Pixmap %lu", pixmap);
+	(void)dpy;
+	(void)pixmap;
+	LOG_DEBUG("glXDestroyGLXPixmap: Pixmap %lu", pixmap);
 }
 
 Bool glXQueryVersion(Display *dpy, int *maj, int *min)
 {
-    (void)dpy;
-    if (maj) {
-        *maj = 1;
-    }
-    if (min) {
-        *min = 4;
-    }
-    return True;
+	(void)dpy;
+	if (maj) {
+		*maj = 1;
+	}
+	if (min) {
+		*min = 4;
+	}
+	return True;
 }
 
 Bool glXIsDirect(Display *dpy, GLXContext ctx)
 {
-    (void)dpy;
-    (void)ctx;
-    return True;
+	(void)dpy;
+	(void)ctx;
+	return True;
 }
 
 int glXGetConfig(Display *dpy, XVisualInfo *visual, int attrib, int *value)
 {
-    (void)dpy;
-    if (!visual || !value) {
-        return GLX_BAD_VALUE;
-    }
+	(void)dpy;
+	if (!visual || !value) {
+		return GLX_BAD_VALUE;
+	}
 
-    switch (attrib) {
-        case GLX_RGBA:
-            *value = True;
-            return 0;
-        case GLX_DEPTH_SIZE:
-            *value = 24;
-            return 0;
-        case GLX_DOUBLEBUFFER:
-            *value = False; // Update if double buffering is supported
-            return 0;
-        default:
-            return GLX_BAD_ATTRIBUTE;
-    }
+	switch (attrib) {
+	case GLX_RGBA:
+		*value = True;
+		return 0;
+	case GLX_DEPTH_SIZE:
+		*value = 24;
+		return 0;
+	case GLX_DOUBLEBUFFER:
+		*value = False; // Update if double buffering is supported
+		return 0;
+	default:
+		return GLX_BAD_ATTRIBUTE;
+	}
 }
 
 GLXContext glXGetCurrentContext(void)
 {
-    pthread_mutex_lock(&ctx_mutex);
-    GLXContext ctx = (GLXContext)current_ctx;
-    pthread_mutex_unlock(&ctx_mutex);
-    return ctx;
+	pthread_mutex_lock(&ctx_mutex);
+	GLXContext ctx = (GLXContext)current_ctx;
+	pthread_mutex_unlock(&ctx_mutex);
+	return ctx;
 }
 
 GLXDrawable glXGetCurrentDrawable(void)
 {
-    pthread_mutex_lock(&ctx_mutex);
-    GLXDrawable drawable = current_ctx ? (GLXDrawable)(uintptr_t)current_ctx->win : 0;
-    pthread_mutex_unlock(&ctx_mutex);
-    return drawable;
+	pthread_mutex_lock(&ctx_mutex);
+	GLXDrawable drawable =
+		current_ctx ? (GLXDrawable)(uintptr_t)current_ctx->win : 0;
+	pthread_mutex_unlock(&ctx_mutex);
+	return drawable;
 }
 
 void glXWaitGL(void)
 {
-    // Assume GL_finish exists in gl_init.h
-    GL_finish();
+	// Assume GL_finish exists in gl_init.h
+	GL_finish();
 }
 
 void glXWaitX(void)
 {
-    pthread_mutex_lock(&ctx_mutex);
-    if (current_ctx && current_ctx->display) {
-        XSync(current_ctx->display, False);
-    }
-    pthread_mutex_unlock(&ctx_mutex);
+	pthread_mutex_lock(&ctx_mutex);
+	if (current_ctx && current_ctx->display) {
+		XSync(current_ctx->display, False);
+	}
+	pthread_mutex_unlock(&ctx_mutex);
 }
 
 void glXUseXFont(Font font, int first, int count, int list)
 {
-    (void)font;
-    (void)first;
-    (void)count;
-    (void)list;
-    LOG_WARN("glXUseXFont: Not implemented");
+	(void)font;
+	(void)first;
+	(void)count;
+	(void)list;
+	LOG_WARN("glXUseXFont: Not implemented");
 }
 
 const char *glXQueryExtensionsString(Display *dpy, int screen)
 {
-    (void)dpy;
-    (void)screen;
-    return "GLX_MICROGLES"; // Custom extension for microGLES
+	(void)dpy;
+	(void)screen;
+	return "GLX_MICROGLES"; // Custom extension for microGLES
 }
 
 const char *glXQueryServerString(Display *dpy, int screen, int name)
 {
-    (void)dpy;
-    (void)screen;
-    (void)name;
-    return "";
+	(void)dpy;
+	(void)screen;
+	(void)name;
+	return "";
 }
 
 const char *glXGetClientString(Display *dpy, int name)
 {
-    (void)dpy;
-    switch (name) {
-        case GLX_VENDOR:
-            return "microGLES";
-        case GLX_VERSION:
-            return "1.4";
-        case GLX_EXTENSIONS:
-            return "GLX_MICROGLES";
-        default:
-            return "";
-    }
+	(void)dpy;
+	switch (name) {
+	case GLX_VENDOR:
+		return "microGLES";
+	case GLX_VERSION:
+		return "1.4";
+	case GLX_EXTENSIONS:
+		return "GLX_MICROGLES";
+	default:
+		return "";
+	}
 }

--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -35,567 +35,656 @@ static pthread_mutex_t fb_mutex = PTHREAD_MUTEX_INITIALIZER;
 // Refreshes thread-local depth and stencil state from the current context.
 static inline void refresh_depth_stencil(void)
 {
-    RenderContext *ctx = GetCurrentContext();
-    if (!ctx) {
-        LOG_ERROR("refresh_depth_stencil: No current context");
-        tl_stencil_on = GL_FALSE;
-        tl_depth_test = GL_FALSE;
-        return;
-    }
+	RenderContext *ctx = GetCurrentContext();
+	if (!ctx) {
+		LOG_ERROR("refresh_depth_stencil: No current context");
+		tl_stencil_on = GL_FALSE;
+		tl_depth_test = GL_FALSE;
+		return;
+	}
 
-    unsigned sv = atomic_load(&ctx->stencil.version);
-    if (sv != tl_stencil_ver) {
-        memcpy(&tl_stencil, &ctx->stencil, sizeof(StencilState));
-        tl_stencil_ver = sv;
-    }
-    tl_stencil_on = ctx->stencil_test_enabled;
+	unsigned sv = atomic_load(&ctx->stencil.version);
+	if (sv != tl_stencil_ver) {
+		memcpy(&tl_stencil, &ctx->stencil, sizeof(StencilState));
+		tl_stencil_ver = sv;
+	}
+	tl_stencil_on = ctx->stencil_test_enabled;
 
-    unsigned dv = atomic_load(&ctx->version_depth);
-    if (dv != tl_depth_ver) {
-        tl_depth_func = ctx->depth_func;
-        tl_depth_test = ctx->depth_test_enabled;
-        tl_depth_ver = dv;
-    } else {
-        tl_depth_test = ctx->depth_test_enabled;
-    }
+	unsigned dv = atomic_load(&ctx->version_depth);
+	if (dv != tl_depth_ver) {
+		tl_depth_func = ctx->depth_func;
+		tl_depth_test = ctx->depth_test_enabled;
+		tl_depth_ver = dv;
+	} else {
+		tl_depth_test = ctx->depth_test_enabled;
+	}
 }
 
 // Creates a framebuffer with the specified dimensions.
 Framebuffer *framebuffer_create(uint32_t width, uint32_t height)
 {
-    if (width == 0 || height == 0 || width > 16384 || height > 16384) {
-        LOG_ERROR("framebuffer_create: Invalid dimensions %ux%u", width, height);
-        return NULL;
-    }
+	if (width == 0 || height == 0 || width > 16384 || height > 16384) {
+		LOG_ERROR("framebuffer_create: Invalid dimensions %ux%u", width,
+			  height);
+		return NULL;
+	}
 
-    pthread_mutex_lock(&fb_mutex);
-    Framebuffer *fb = (Framebuffer *)tracked_malloc(sizeof(Framebuffer));
-    if (!fb) {
-        LOG_ERROR("framebuffer_create: Failed to allocate Framebuffer");
-        pthread_mutex_unlock(&fb_mutex);
-        return NULL;
-    }
+	pthread_mutex_lock(&fb_mutex);
+	Framebuffer *fb = (Framebuffer *)tracked_malloc(sizeof(Framebuffer));
+	if (!fb) {
+		LOG_ERROR("framebuffer_create: Failed to allocate Framebuffer");
+		pthread_mutex_unlock(&fb_mutex);
+		return NULL;
+	}
 
-    fb->width = width;
-    fb->height = height;
-    atomic_init(&fb->ref_count, 1);
-    size_t pixels = (size_t)width * height;
+	fb->width = width;
+	fb->height = height;
+	atomic_init(&fb->ref_count, 1);
+	size_t pixels = (size_t)width * height;
 
-    fb->color_buffer = (_Atomic uint32_t *)tracked_aligned_alloc(
-        64, pixels * sizeof(_Atomic uint32_t));
-    fb->depth_buffer = (_Atomic float *)tracked_aligned_alloc(
-        64, pixels * sizeof(_Atomic float));
-    fb->stencil_buffer = (_Atomic uint8_t *)tracked_aligned_alloc(
-        64, pixels * sizeof(_Atomic uint8_t));
+	fb->color_buffer = (_Atomic uint32_t *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic uint32_t));
+	fb->depth_buffer = (_Atomic float *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic float));
+	fb->stencil_buffer = (_Atomic uint8_t *)tracked_aligned_alloc(
+		64, pixels * sizeof(_Atomic uint8_t));
 
-    if (!fb->color_buffer || !fb->depth_buffer || !fb->stencil_buffer) {
-        LOG_ERROR("framebuffer_create: Failed to allocate buffers");
-        if (fb->color_buffer) {
-            tracked_free(fb->color_buffer, pixels * sizeof(_Atomic uint32_t));
-        }
-        if (fb->depth_buffer) {
-            tracked_free(fb->depth_buffer, pixels * sizeof(_Atomic float));
-        }
-        if (fb->stencil_buffer) {
-            tracked_free(fb->stencil_buffer, pixels * sizeof(_Atomic uint8_t));
-        }
-        tracked_free(fb, sizeof(Framebuffer));
-        pthread_mutex_unlock(&fb_mutex);
-        return NULL;
-    }
+	if (!fb->color_buffer || !fb->depth_buffer || !fb->stencil_buffer) {
+		LOG_ERROR("framebuffer_create: Failed to allocate buffers");
+		if (fb->color_buffer) {
+			tracked_free(fb->color_buffer,
+				     pixels * sizeof(_Atomic uint32_t));
+		}
+		if (fb->depth_buffer) {
+			tracked_free(fb->depth_buffer,
+				     pixels * sizeof(_Atomic float));
+		}
+		if (fb->stencil_buffer) {
+			tracked_free(fb->stencil_buffer,
+				     pixels * sizeof(_Atomic uint8_t));
+		}
+		tracked_free(fb, sizeof(Framebuffer));
+		pthread_mutex_unlock(&fb_mutex);
+		return NULL;
+	}
 
-    fb->tiles_x = (width + TILE_SIZE - 1) / TILE_SIZE;
-    fb->tiles_y = (height + TILE_SIZE - 1) / TILE_SIZE;
-    size_t tile_count = (size_t)fb->tiles_x * fb->tiles_y;
-    fb->tiles = (FramebufferTile *)tracked_malloc(tile_count * sizeof(FramebufferTile));
-    if (!fb->tiles) {
-        LOG_ERROR("framebuffer_create: Failed to allocate tiles");
-        tracked_free(fb->color_buffer, pixels * sizeof(_Atomic uint32_t));
-        tracked_free(fb->depth_buffer, pixels * sizeof(_Atomic float));
-        tracked_free(fb->stencil_buffer, pixels * sizeof(_Atomic uint8_t));
-        tracked_free(fb, sizeof(Framebuffer));
-        pthread_mutex_unlock(&fb_mutex);
-        return NULL;
-    }
+	fb->tiles_x = (width + TILE_SIZE - 1) / TILE_SIZE;
+	fb->tiles_y = (height + TILE_SIZE - 1) / TILE_SIZE;
+	size_t tile_count = (size_t)fb->tiles_x * fb->tiles_y;
+	fb->tiles = (FramebufferTile *)tracked_malloc(tile_count *
+						      sizeof(FramebufferTile));
+	if (!fb->tiles) {
+		LOG_ERROR("framebuffer_create: Failed to allocate tiles");
+		tracked_free(fb->color_buffer,
+			     pixels * sizeof(_Atomic uint32_t));
+		tracked_free(fb->depth_buffer, pixels * sizeof(_Atomic float));
+		tracked_free(fb->stencil_buffer,
+			     pixels * sizeof(_Atomic uint8_t));
+		tracked_free(fb, sizeof(Framebuffer));
+		pthread_mutex_unlock(&fb_mutex);
+		return NULL;
+	}
 
-    for (size_t i = 0; i < tile_count; ++i) {
-        fb->tiles[i].x0 = (i % fb->tiles_x) * TILE_SIZE;
-        fb->tiles[i].y0 = (i / fb->tiles_x) * TILE_SIZE;
-        atomic_flag_clear(&fb->tiles[i].lock);
-        fb->tiles[i].color = fb->color_buffer + fb->tiles[i].y0 * width + fb->tiles[i].x0;
-        fb->tiles[i].depth = fb->depth_buffer + fb->tiles[i].y0 * width + fb->tiles[i].x0;
-        fb->tiles[i].stencil = fb->stencil_buffer + fb->tiles[i].y0 * width + fb->tiles[i].x0;
-    }
+	for (size_t i = 0; i < tile_count; ++i) {
+		fb->tiles[i].x0 = (i % fb->tiles_x) * TILE_SIZE;
+		fb->tiles[i].y0 = (i / fb->tiles_x) * TILE_SIZE;
+		atomic_flag_clear(&fb->tiles[i].lock);
+		memset(fb->tiles[i].color, 0, sizeof(fb->tiles[i].color));
+		memset(fb->tiles[i].depth, 0, sizeof(fb->tiles[i].depth));
+		memset(fb->tiles[i].stencil, 0, sizeof(fb->tiles[i].stencil));
+	}
 
-    framebuffer_clear(fb, 0, 1.0f, 0);
-    LOG_INFO("Created framebuffer %ux%u with %zu tiles", width, height, tile_count);
-    pthread_mutex_unlock(&fb_mutex);
-    return fb;
+	framebuffer_clear(fb, 0, 1.0f, 0);
+	LOG_INFO("Created framebuffer %ux%u with %zu tiles", width, height,
+		 tile_count);
+	pthread_mutex_unlock(&fb_mutex);
+	return fb;
 }
 
 // Increments the framebuffer's reference count.
 void framebuffer_retain(Framebuffer *fb)
 {
-    if (!fb) {
-        return;
-    }
-    atomic_fetch_add_explicit(&fb->ref_count, 1, memory_order_relaxed);
+	if (!fb) {
+		return;
+	}
+	atomic_fetch_add_explicit(&fb->ref_count, 1, memory_order_relaxed);
 }
 
 // Frees the framebuffer's resources.
 static void framebuffer_free(Framebuffer *fb)
 {
-    if (!fb) {
-        return;
-    }
-    size_t pixels = (size_t)fb->width * fb->height;
-    size_t tile_count = (size_t)fb->tiles_x * fb->tiles_y;
-    if (fb->color_buffer) {
-        tracked_free((void *)fb->color_buffer, pixels * sizeof(_Atomic uint32_t));
-    }
-    if (fb->depth_buffer) {
-        tracked_free((void *)fb->depth_buffer, pixels * sizeof(_Atomic float));
-    }
-    if (fb->stencil_buffer) {
-        tracked_free((void *)fb->stencil_buffer, pixels * sizeof(_Atomic uint8_t));
-    }
-    if (fb->tiles) {
-        tracked_free(fb->tiles, tile_count * sizeof(FramebufferTile));
-    }
-    tracked_free(fb, sizeof(Framebuffer));
+	if (!fb) {
+		return;
+	}
+	size_t pixels = (size_t)fb->width * fb->height;
+	size_t tile_count = (size_t)fb->tiles_x * fb->tiles_y;
+	if (fb->color_buffer) {
+		tracked_free((void *)fb->color_buffer,
+			     pixels * sizeof(_Atomic uint32_t));
+	}
+	if (fb->depth_buffer) {
+		tracked_free((void *)fb->depth_buffer,
+			     pixels * sizeof(_Atomic float));
+	}
+	if (fb->stencil_buffer) {
+		tracked_free((void *)fb->stencil_buffer,
+			     pixels * sizeof(_Atomic uint8_t));
+	}
+	if (fb->tiles) {
+		tracked_free(fb->tiles, tile_count * sizeof(FramebufferTile));
+	}
+	tracked_free(fb, sizeof(Framebuffer));
 }
 
 // Decrements the framebuffer's reference count and frees if zero.
 void framebuffer_release(Framebuffer *fb)
 {
-    if (!fb) {
-        return;
-    }
-    if (atomic_fetch_sub_explicit(&fb->ref_count, 1, memory_order_acq_rel) == 1) {
-        pthread_mutex_lock(&fb_mutex);
-        framebuffer_free(fb);
-        pthread_mutex_unlock(&fb_mutex);
-    }
+	if (!fb) {
+		return;
+	}
+	if (atomic_fetch_sub_explicit(&fb->ref_count, 1,
+				      memory_order_acq_rel) == 1) {
+		pthread_mutex_lock(&fb_mutex);
+		framebuffer_free(fb);
+		pthread_mutex_unlock(&fb_mutex);
+	}
 }
 
 // Destroys the framebuffer, ensuring thread pool tasks are completed.
 void framebuffer_destroy(Framebuffer *fb)
 {
-    if (!fb) {
-        return;
-    }
-    if (thread_pool_active()) {
-        command_buffer_flush();
-        thread_pool_wait();
-    }
-    framebuffer_release(fb);
+	if (!fb) {
+		return;
+	}
+	if (thread_pool_active()) {
+		command_buffer_flush();
+		thread_pool_wait();
+	}
+	framebuffer_release(fb);
 }
 
 // Clears the framebuffer with specified color, depth, and stencil values.
 void framebuffer_clear(Framebuffer *restrict fb, uint32_t clear_color,
-                       float clear_depth, uint8_t clear_stencil)
+		       float clear_depth, uint8_t clear_stencil)
 {
-    if (!fb) {
-        LOG_ERROR("framebuffer_clear: NULL framebuffer");
-        return;
-    }
+	if (!fb) {
+		LOG_ERROR("framebuffer_clear: NULL framebuffer");
+		return;
+	}
 
-    size_t pixels = (size_t)fb->width * fb->height;
-    // Use memset for faster clearing where possible
-    if (clear_color == 0) {
-        memset(fb->color_buffer, 0, pixels * sizeof(_Atomic uint32_t));
-    } else {
-        for (size_t i = 0; i < pixels; ++i) {
-            atomic_store(&fb->color_buffer[i], clear_color);
-        }
-    }
-    if (clear_depth == 0.0f) {
-        memset(fb->depth_buffer, 0, pixels * sizeof(_Atomic float));
-    } else {
-        for (size_t i = 0; i < pixels; ++i) {
-            atomic_store(&fb->depth_buffer[i], clear_depth);
-        }
-    }
-    if (clear_stencil == 0) {
-        memset(fb->stencil_buffer, 0, pixels * sizeof(_Atomic uint8_t));
-    } else {
-        for (size_t i = 0; i < pixels; ++i) {
-            atomic_store(&fb->stencil_buffer[i], clear_stencil);
-        }
-    }
+	size_t pixels = (size_t)fb->width * fb->height;
+	// Use memset for faster clearing where possible
+	if (clear_color == 0) {
+		memset(fb->color_buffer, 0, pixels * sizeof(_Atomic uint32_t));
+	} else {
+		for (size_t i = 0; i < pixels; ++i) {
+			atomic_store(&fb->color_buffer[i], clear_color);
+		}
+	}
+	if (clear_depth == 0.0f) {
+		memset(fb->depth_buffer, 0, pixels * sizeof(_Atomic float));
+	} else {
+		for (size_t i = 0; i < pixels; ++i) {
+			atomic_store(&fb->depth_buffer[i], clear_depth);
+		}
+	}
+	if (clear_stencil == 0) {
+		memset(fb->stencil_buffer, 0, pixels * sizeof(_Atomic uint8_t));
+	} else {
+		for (size_t i = 0; i < pixels; ++i) {
+			atomic_store(&fb->stencil_buffer[i], clear_stencil);
+		}
+	}
 }
 
 // Asynchronous clear task structure.
 typedef struct {
-    Framebuffer *fb;
-    uint32_t color;
-    float depth;
-    uint8_t stencil;
+	Framebuffer *fb;
+	uint32_t color;
+	float depth;
+	uint8_t stencil;
 } ClearTask;
 
 // Executes an asynchronous clear task.
 static void clear_task_func(void *arg)
 {
-    ClearTask *t = (ClearTask *)arg;
-    if (!t || !t->fb) {
-        LOG_ERROR("clear_task_func: Invalid task or framebuffer");
-        if (t) {
-            MT_FREE(t, STAGE_FRAMEBUFFER);
-        }
-        return;
-    }
-    framebuffer_clear(t->fb, t->color, t->depth, t->stencil);
-    framebuffer_release(t->fb);
-    MT_FREE(t, STAGE_FRAMEBUFFER);
-    LOG_DEBUG("framebuffer_clear_async task completed");
+	ClearTask *t = (ClearTask *)arg;
+	if (!t || !t->fb) {
+		LOG_ERROR("clear_task_func: Invalid task or framebuffer");
+		if (t) {
+			MT_FREE(t, STAGE_FRAMEBUFFER);
+		}
+		return;
+	}
+	framebuffer_clear(t->fb, t->color, t->depth, t->stencil);
+	framebuffer_release(t->fb);
+	MT_FREE(t, STAGE_FRAMEBUFFER);
+	LOG_DEBUG("framebuffer_clear_async task completed");
 }
 
 // Clears the framebuffer asynchronously via the thread pool.
 void framebuffer_clear_async(Framebuffer *fb, uint32_t clear_color,
-                             float clear_depth, uint8_t clear_stencil)
+			     float clear_depth, uint8_t clear_stencil)
 {
-    if (!fb) {
-        LOG_ERROR("framebuffer_clear_async: NULL framebuffer");
-        return;
-    }
-    if (!thread_pool_active()) {
-        framebuffer_clear(fb, clear_color, clear_depth, clear_stencil);
-        return;
-    }
+	if (!fb) {
+		LOG_ERROR("framebuffer_clear_async: NULL framebuffer");
+		return;
+	}
+	if (!thread_pool_active()) {
+		framebuffer_clear(fb, clear_color, clear_depth, clear_stencil);
+		return;
+	}
 
-    ClearTask *task = MT_ALLOC(sizeof(ClearTask), STAGE_FRAMEBUFFER);
-    if (!task) {
-        LOG_ERROR("framebuffer_clear_async: Failed to allocate ClearTask");
-        framebuffer_clear(fb, clear_color, clear_depth, clear_stencil);
-        return;
-    }
+	ClearTask *task = MT_ALLOC(sizeof(ClearTask), STAGE_FRAMEBUFFER);
+	if (!task) {
+		LOG_ERROR(
+			"framebuffer_clear_async: Failed to allocate ClearTask");
+		framebuffer_clear(fb, clear_color, clear_depth, clear_stencil);
+		return;
+	}
 
-    framebuffer_retain(fb);
-    task->fb = fb;
-    task->color = clear_color;
-    task->depth = clear_depth;
-    task->stencil = clear_stencil;
-    command_buffer_record_task(clear_task_func, task, STAGE_FRAMEBUFFER);
-    LOG_DEBUG("Scheduled async clear for framebuffer %p", fb);
+	framebuffer_retain(fb);
+	task->fb = fb;
+	task->color = clear_color;
+	task->depth = clear_depth;
+	task->stencil = clear_stencil;
+	command_buffer_record_task(clear_task_func, task, STAGE_FRAMEBUFFER);
+	LOG_DEBUG("Scheduled async clear for framebuffer %p", fb);
 }
 
 // Sets a pixel with color and depth, applying stencil and depth tests.
 void framebuffer_set_pixel(Framebuffer *restrict fb, uint32_t x, uint32_t y,
-                           uint32_t color, float depth)
+			   uint32_t color, float depth)
 {
-    if (!fb || x >= fb->width || y >= fb->height) {
-        return;
-    }
+	if (!fb || x >= fb->width || y >= fb->height) {
+		return;
+	}
 
-    _Atomic uint32_t *color_buffer = fb->color_buffer;
-    _Atomic float *depth_buffer = fb->depth_buffer;
-    _Atomic uint8_t *stencil_buffer = fb->stencil_buffer;
-    size_t stride = fb->width;
-    uint32_t tile_x = x, tile_y = y;
+	_Atomic uint32_t *color_buffer = fb->color_buffer;
+	_Atomic float *depth_buffer = fb->depth_buffer;
+	_Atomic uint8_t *stencil_buffer = fb->stencil_buffer;
+	size_t stride = fb->width;
+	uint32_t tile_x = x, tile_y = y;
 
-    if (tls_tile && x >= tls_tile->x0 && x < tls_tile->x0 + TILE_SIZE &&
-        y >= tls_tile->y0 && y < tls_tile->y0 + TILE_SIZE) {
-        color_buffer = (_Atomic uint32_t *)tls_tile->color;
-        depth_buffer = (_Atomic float *)tls_tile->depth;
-        stencil_buffer = (_Atomic uint8_t *)tls_tile->stencil;
-        stride = TILE_SIZE;
-        tile_x = x - tls_tile->x0;
-        tile_y = y - tls_tile->y0;
-    }
+	if (tls_tile && x >= tls_tile->x0 && x < tls_tile->x0 + TILE_SIZE &&
+	    y >= tls_tile->y0 && y < tls_tile->y0 + TILE_SIZE) {
+		color_buffer = (_Atomic uint32_t *)tls_tile->color;
+		depth_buffer = (_Atomic float *)tls_tile->depth;
+		stencil_buffer = (_Atomic uint8_t *)tls_tile->stencil;
+		stride = TILE_SIZE;
+		tile_x = x - tls_tile->x0;
+		tile_y = y - tls_tile->y0;
+	}
 
-    size_t idx = (size_t)tile_y * stride + tile_x;
-    refresh_depth_stencil();
-    GLboolean stencil_on = tl_stencil_on;
-    StencilState *ss = &tl_stencil;
-    uint8_t stencil = atomic_load(&stencil_buffer[idx]);
+	size_t idx = (size_t)tile_y * stride + tile_x;
+	refresh_depth_stencil();
+	GLboolean stencil_on = tl_stencil_on;
+	StencilState *ss = &tl_stencil;
+	uint8_t stencil = atomic_load(&stencil_buffer[idx]);
 
-    if (stencil_on) {
-        uint8_t masked = stencil & ss->mask;
-        uint8_t ref = ss->ref & ss->mask;
-        bool pass = false;
-        switch (ss->func) {
-            case GL_NEVER: pass = false; break;
-            case GL_LESS: pass = masked < ref; break;
-            case GL_LEQUAL: pass = masked <= ref; break;
-            case GL_GREATER: pass = masked > ref; break;
-            case GL_GEQUAL: pass = masked >= ref; break;
-            case GL_EQUAL: pass = masked == ref; break;
-            case GL_NOTEQUAL: pass = masked != ref; break;
-            case GL_ALWAYS: pass = true; break;
-        }
-        if (!pass) {
-            uint8_t new = stencil;
-            switch (ss->sfail) {
-                case GL_ZERO: new = 0; break;
-                case GL_REPLACE: new = ss->ref; break;
-                case GL_INCR: new = (stencil == 0xFF) ? 0xFF : stencil + 1; break;
-                case GL_DECR: new = (stencil == 0) ? 0 : stencil - 1; break;
-                case GL_INVERT: new = ~stencil; break;
-                case GL_INCR_WRAP: new = stencil + 1; break;
-                case GL_DECR_WRAP: new = stencil - 1; break;
-                case GL_KEEP: default: break;
-            }
-            new = (new & ss->writemask) | (stencil & ~ss->writemask);
-            atomic_store(&stencil_buffer[idx], new);
-            return;
-        }
-    }
+	if (stencil_on) {
+		uint8_t masked = stencil & ss->mask;
+		uint8_t ref = ss->ref & ss->mask;
+		bool pass = false;
+		switch (ss->func) {
+		case GL_NEVER:
+			pass = false;
+			break;
+		case GL_LESS:
+			pass = masked < ref;
+			break;
+		case GL_LEQUAL:
+			pass = masked <= ref;
+			break;
+		case GL_GREATER:
+			pass = masked > ref;
+			break;
+		case GL_GEQUAL:
+			pass = masked >= ref;
+			break;
+		case GL_EQUAL:
+			pass = masked == ref;
+			break;
+		case GL_NOTEQUAL:
+			pass = masked != ref;
+			break;
+		case GL_ALWAYS:
+			pass = true;
+			break;
+		}
+		if (!pass) {
+			uint8_t new = stencil;
+			switch (ss->sfail) {
+			case GL_ZERO:
+				new = 0;
+				break;
+			case GL_REPLACE:
+				new = ss->ref;
+				break;
+			case GL_INCR:
+				new = (stencil == 0xFF) ? 0xFF : stencil + 1;
+				break;
+			case GL_DECR:
+				new = (stencil == 0) ? 0 : stencil - 1;
+				break;
+			case GL_INVERT:
+				new = ~stencil;
+				break;
+			case GL_INCR_WRAP:
+				new = stencil + 1;
+				break;
+			case GL_DECR_WRAP:
+				new = stencil - 1;
+				break;
+			case GL_KEEP:
+			default:
+				break;
+			}
+			new = (new & ss->writemask) |
+			      (stencil & ~ss->writemask);
+			atomic_store(&stencil_buffer[idx], new);
+			return;
+		}
+	}
 
-    float current = atomic_load(&depth_buffer[idx]);
-    bool depth_pass = false;
-    if (!tl_depth_test) {
-        depth_pass = true;
-    } else {
-        while (true) {
-            bool pass = false;
-            switch (tl_depth_func) {
-                case GL_NEVER: pass = false; break;
-                case GL_LESS: pass = depth < current; break;
-                case GL_LEQUAL: pass = depth <= current; break;
-                case GL_GREATER: pass = depth > current; break;
-                case GL_GEQUAL: pass = depth >= current; break;
-                case GL_EQUAL: pass = depth == current; break;
-                case GL_NOTEQUAL: pass = depth != current; break;
-                case GL_ALWAYS: pass = true; break;
-                default: pass = depth < current; break;
-            }
-            if (!pass) {
-                break;
-            }
-            if (atomic_compare_exchange_weak(&depth_buffer[idx], &current, depth)) {
-                depth_pass = true;
-                break;
-            }
-        }
-    }
+	float current = atomic_load(&depth_buffer[idx]);
+	bool depth_pass = false;
+	if (!tl_depth_test) {
+		depth_pass = true;
+	} else {
+		while (true) {
+			bool pass = false;
+			switch (tl_depth_func) {
+			case GL_NEVER:
+				pass = false;
+				break;
+			case GL_LESS:
+				pass = depth < current;
+				break;
+			case GL_LEQUAL:
+				pass = depth <= current;
+				break;
+			case GL_GREATER:
+				pass = depth > current;
+				break;
+			case GL_GEQUAL:
+				pass = depth >= current;
+				break;
+			case GL_EQUAL:
+				pass = depth == current;
+				break;
+			case GL_NOTEQUAL:
+				pass = depth != current;
+				break;
+			case GL_ALWAYS:
+				pass = true;
+				break;
+			default:
+				pass = depth < current;
+				break;
+			}
+			if (!pass) {
+				break;
+			}
+			if (atomic_compare_exchange_weak(&depth_buffer[idx],
+							 &current, depth)) {
+				depth_pass = true;
+				break;
+			}
+		}
+	}
 
-    if (stencil_on) {
-        uint8_t new = stencil;
-        GLenum op = depth_pass ? ss->zpass : ss->zfail;
-        switch (op) {
-            case GL_ZERO: new = 0; break;
-            case GL_REPLACE: new = ss->ref; break;
-            case GL_INCR: new = (stencil == 0xFF) ? 0xFF : stencil + 1; break;
-            case GL_DECR: new = (stencil == 0) ? 0 : stencil - 1; break;
-            case GL_INVERT: new = ~stencil; break;
-            case GL_INCR_WRAP: new = stencil + 1; break;
-            case GL_DECR_WRAP: new = stencil - 1; break;
-            case GL_KEEP: default: break;
-        }
-        new = (new & ss->writemask) | (stencil & ~ss->writemask);
-        atomic_store(&stencil_buffer[idx], new);
-    }
+	if (stencil_on) {
+		uint8_t new = stencil;
+		GLenum op = depth_pass ? ss->zpass : ss->zfail;
+		switch (op) {
+		case GL_ZERO:
+			new = 0;
+			break;
+		case GL_REPLACE:
+			new = ss->ref;
+			break;
+		case GL_INCR:
+			new = (stencil == 0xFF) ? 0xFF : stencil + 1;
+			break;
+		case GL_DECR:
+			new = (stencil == 0) ? 0 : stencil - 1;
+			break;
+		case GL_INVERT:
+			new = ~stencil;
+			break;
+		case GL_INCR_WRAP:
+			new = stencil + 1;
+			break;
+		case GL_DECR_WRAP:
+			new = stencil - 1;
+			break;
+		case GL_KEEP:
+		default:
+			break;
+		}
+		new = (new & ss->writemask) | (stencil & ~ss->writemask);
+		atomic_store(&stencil_buffer[idx], new);
+	}
 
-    if (depth_pass) {
-        atomic_store(&color_buffer[idx], color);
-    }
+	if (depth_pass) {
+		atomic_store(&color_buffer[idx], color);
+	}
 }
 
 // Fills a rectangle with the specified color and depth.
 void framebuffer_fill_rect(Framebuffer *fb, uint32_t x0, uint32_t y0,
-                           uint32_t x1, uint32_t y1, uint32_t color,
-                           float depth)
+			   uint32_t x1, uint32_t y1, uint32_t color,
+			   float depth)
 {
-    if (!fb || x0 > x1 || y0 > y1 || x1 >= fb->width || y1 >= fb->height) {
-        LOG_ERROR("framebuffer_fill_rect: Invalid parameters");
-        return;
-    }
-    for (uint32_t y = y0; y <= y1; ++y) {
-        for (uint32_t x = x0; x <= x1; ++x) {
-            framebuffer_set_pixel(fb, x, y, color, depth);
-        }
-    }
+	if (!fb || x0 > x1 || y0 > y1 || x1 >= fb->width || y1 >= fb->height) {
+		LOG_ERROR("framebuffer_fill_rect: Invalid parameters");
+		return;
+	}
+	for (uint32_t y = y0; y <= y1; ++y) {
+		for (uint32_t x = x0; x <= x1; ++x) {
+			framebuffer_set_pixel(fb, x, y, color, depth);
+		}
+	}
 }
 
 // Gets the color value of a pixel.
 uint32_t framebuffer_get_pixel(const Framebuffer *fb, uint32_t x, uint32_t y)
 {
-    if (!fb || x >= fb->width || y >= fb->height) {
-        return 0;
-    }
-    return atomic_load(&fb->color_buffer[(size_t)y * fb->width + x]);
+	if (!fb || x >= fb->width || y >= fb->height) {
+		return 0;
+	}
+	return atomic_load(&fb->color_buffer[(size_t)y * fb->width + x]);
 }
 
 // Gets the depth value of a pixel.
 float framebuffer_get_depth(const Framebuffer *fb, uint32_t x, uint32_t y)
 {
-    if (!fb || x >= fb->width || y >= fb->height) {
-        return 1.0f;
-    }
-    return atomic_load(&fb->depth_buffer[(size_t)y * fb->width + x]);
+	if (!fb || x >= fb->width || y >= fb->height) {
+		return 1.0f;
+	}
+	return atomic_load(&fb->depth_buffer[(size_t)y * fb->width + x]);
 }
 
 // Writes the framebuffer to a BMP file.
 int framebuffer_write_bmp(const Framebuffer *fb, const char *path)
 {
-    if (!fb || !path) {
-        LOG_ERROR("framebuffer_write_bmp: NULL framebuffer or path");
-        return 0;
-    }
+	if (!fb || !path) {
+		LOG_ERROR("framebuffer_write_bmp: NULL framebuffer or path");
+		return 0;
+	}
 
-    FILE *f = fopen(path, "wb");
-    if (!f) {
-        LOG_ERROR("framebuffer_write_bmp: Failed to open %s", path);
-        return 0;
-    }
+	FILE *f = fopen(path, "wb");
+	if (!f) {
+		LOG_ERROR("framebuffer_write_bmp: Failed to open %s", path);
+		return 0;
+	}
 
-    int width = (int)fb->width;
-    int height = (int)fb->height;
-    int row_bytes = width * 3;
-    int row_padded = (row_bytes + 3) & ~3;
-    uint32_t filesize = 54 + row_padded * height;
+	int width = (int)fb->width;
+	int height = (int)fb->height;
+	int row_bytes = width * 3;
+	int row_padded = (row_bytes + 3) & ~3;
+	uint32_t filesize = 54 + row_padded * height;
 
-    unsigned char file_header[14] = { 'B', 'M' };
-    file_header[2] = (unsigned char)(filesize);
-    file_header[3] = (unsigned char)(filesize >> 8);
-    file_header[4] = (unsigned char)(filesize >> 16);
-    file_header[5] = (unsigned char)(filesize >> 24);
-    file_header[10] = 54;
-    if (fwrite(file_header, 1, 14, f) != 14) {
-        LOG_ERROR("framebuffer_write_bmp: Failed to write file header");
-        fclose(f);
-        return 0;
-    }
+	unsigned char file_header[14] = { 'B', 'M' };
+	file_header[2] = (unsigned char)(filesize);
+	file_header[3] = (unsigned char)(filesize >> 8);
+	file_header[4] = (unsigned char)(filesize >> 16);
+	file_header[5] = (unsigned char)(filesize >> 24);
+	file_header[10] = 54;
+	if (fwrite(file_header, 1, 14, f) != 14) {
+		LOG_ERROR("framebuffer_write_bmp: Failed to write file header");
+		fclose(f);
+		return 0;
+	}
 
-    unsigned char info_header[40] = { 0 };
-    info_header[0] = 40;
-    info_header[4] = (unsigned char)(width);
-    info_header[5] = (unsigned char)(width >> 8);
-    info_header[6] = (unsigned char)(width >> 16);
-    info_header[7] = (unsigned char)(width >> 24);
-    info_header[8] = (unsigned char)(height);
-    info_header[9] = (unsigned char)(height >> 8);
-    info_header[10] = (unsigned char)(height >> 16);
-    info_header[11] = (unsigned char)(height >> 24);
-    info_header[12] = 1;
-    info_header[14] = 24;
-    if (fwrite(info_header, 1, 40, f) != 40) {
-        LOG_ERROR("framebuffer_write_bmp: Failed to write info header");
-        fclose(f);
-        return 0;
-    }
+	unsigned char info_header[40] = { 0 };
+	info_header[0] = 40;
+	info_header[4] = (unsigned char)(width);
+	info_header[5] = (unsigned char)(width >> 8);
+	info_header[6] = (unsigned char)(width >> 16);
+	info_header[7] = (unsigned char)(width >> 24);
+	info_header[8] = (unsigned char)(height);
+	info_header[9] = (unsigned char)(height >> 8);
+	info_header[10] = (unsigned char)(height >> 16);
+	info_header[11] = (unsigned char)(height >> 24);
+	info_header[12] = 1;
+	info_header[14] = 24;
+	if (fwrite(info_header, 1, 40, f) != 40) {
+		LOG_ERROR("framebuffer_write_bmp: Failed to write info header");
+		fclose(f);
+		return 0;
+	}
 
-    unsigned char *row = (unsigned char *)tracked_malloc(row_padded);
-    if (!row) {
-        LOG_ERROR("framebuffer_write_bmp: Failed to allocate row buffer");
-        fclose(f);
-        return 0;
-    }
+	unsigned char *row = (unsigned char *)tracked_malloc(row_padded);
+	if (!row) {
+		LOG_ERROR(
+			"framebuffer_write_bmp: Failed to allocate row buffer");
+		fclose(f);
+		return 0;
+	}
 
-    for (int y = height - 1; y >= 0; --y) {
-        for (int x = 0; x < width; ++x) {
-            uint32_t pixel = atomic_load(&fb->color_buffer[(size_t)y * fb->width + x]);
-            row[x * 3 + 0] = (pixel >> 0) & 0xFF;  // B
-            row[x * 3 + 1] = (pixel >> 8) & 0xFF;  // G
-            row[x * 3 + 2] = (pixel >> 16) & 0xFF; // R
-        }
-        memset(row + row_bytes, 0, row_padded - row_bytes);
-        if (fwrite(row, 1, row_padded, f) != (size_t)row_padded) {
-            LOG_ERROR("framebuffer_write_bmp: Failed to write row data");
-            tracked_free(row, row_padded);
-            fclose(f);
-            return 0;
-        }
-    }
+	for (int y = height - 1; y >= 0; --y) {
+		for (int x = 0; x < width; ++x) {
+			uint32_t pixel = atomic_load(
+				&fb->color_buffer[(size_t)y * fb->width + x]);
+			row[x * 3 + 0] = (pixel >> 0) & 0xFF; // B
+			row[x * 3 + 1] = (pixel >> 8) & 0xFF; // G
+			row[x * 3 + 2] = (pixel >> 16) & 0xFF; // R
+		}
+		memset(row + row_bytes, 0, row_padded - row_bytes);
+		if (fwrite(row, 1, row_padded, f) != (size_t)row_padded) {
+			LOG_ERROR(
+				"framebuffer_write_bmp: Failed to write row data");
+			tracked_free(row, row_padded);
+			fclose(f);
+			return 0;
+		}
+	}
 
-    tracked_free(row, row_padded);
-    if (fclose(f) != 0) {
-        LOG_ERROR("framebuffer_write_bmp: Failed to close %s", path);
-        return 0;
-    }
-    LOG_INFO("Wrote BMP to %s", path);
-    return 1;
+	tracked_free(row, row_padded);
+	if (fclose(f) != 0) {
+		LOG_ERROR("framebuffer_write_bmp: Failed to close %s", path);
+		return 0;
+	}
+	LOG_INFO("Wrote BMP to %s", path);
+	return 1;
 }
 
 // Writes the framebuffer to an RGBA text file.
 int framebuffer_write_rgba(const Framebuffer *fb, const char *path)
 {
-    if (!fb || !path) {
-        LOG_ERROR("framebuffer_write_rgba: NULL framebuffer or path");
-        return 0;
-    }
+	if (!fb || !path) {
+		LOG_ERROR("framebuffer_write_rgba: NULL framebuffer or path");
+		return 0;
+	}
 
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        LOG_ERROR("framebuffer_write_rgba: Failed to open %s", path);
-        return 0;
-    }
+	FILE *f = fopen(path, "w");
+	if (!f) {
+		LOG_ERROR("framebuffer_write_rgba: Failed to open %s", path);
+		return 0;
+	}
 
-    int width = (int)fb->width;
-    int height = (int)fb->height;
-    if (fprintf(f, "%d %d\n", width, height) < 0) {
-        LOG_ERROR("framebuffer_write_rgba: Failed to write header");
-        fclose(f);
-        return 0;
-    }
+	int width = (int)fb->width;
+	int height = (int)fb->height;
+	if (fprintf(f, "%d %d\n", width, height) < 0) {
+		LOG_ERROR("framebuffer_write_rgba: Failed to write header");
+		fclose(f);
+		return 0;
+	}
 
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            uint32_t pixel = atomic_load(&fb->color_buffer[(size_t)y * fb->width + x]);
-            unsigned r = (pixel >> 16) & 0xFF;
-            unsigned g = (pixel >> 8) & 0xFF;
-            unsigned b = pixel & 0xFF;
-            if (fprintf(f, "%u %u %u 255\n", r, g, b) < 0) {
-                LOG_ERROR("framebuffer_write_rgba: Failed to write pixel data");
-                fclose(f);
-                return 0;
-            }
-        }
-    }
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			uint32_t pixel = atomic_load(
+				&fb->color_buffer[(size_t)y * fb->width + x]);
+			unsigned r = (pixel >> 16) & 0xFF;
+			unsigned g = (pixel >> 8) & 0xFF;
+			unsigned b = pixel & 0xFF;
+			if (fprintf(f, "%u %u %u 255\n", r, g, b) < 0) {
+				LOG_ERROR(
+					"framebuffer_write_rgba: Failed to write pixel data");
+				fclose(f);
+				return 0;
+			}
+		}
+	}
 
-    if (fclose(f) != 0) {
-        LOG_ERROR("framebuffer_write_rgba: Failed to close %s", path);
-        return 0;
-    }
-    LOG_INFO("Wrote RGBA to %s", path);
-    return 1;
+	if (fclose(f) != 0) {
+		LOG_ERROR("framebuffer_write_rgba: Failed to close %s", path);
+		return 0;
+	}
+	LOG_INFO("Wrote RGBA to %s", path);
+	return 1;
 }
 
 // Streams the framebuffer as RGBA bytes to a file stream.
 int framebuffer_stream_rgba(const Framebuffer *fb, FILE *out)
 {
-    if (!fb || !out) {
-        LOG_ERROR("framebuffer_stream_rgba: NULL framebuffer or stream");
-        return 0;
-    }
+	if (!fb || !out) {
+		LOG_ERROR(
+			"framebuffer_stream_rgba: NULL framebuffer or stream");
+		return 0;
+	}
 
-    int width = (int)fb->width;
-    int height = (int)fb->height;
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            uint32_t pixel = atomic_load(&fb->color_buffer[(size_t)y * fb->width + x]);
-            unsigned char bytes[4] = {
-                (unsigned char)((pixel >> 16) & 0xFF), // R
-                (unsigned char)((pixel >> 8) & 0xFF),  // G
-                (unsigned char)(pixel & 0xFF),         // B
-                (unsigned char)((pixel >> 24) & 0xFF)  // A
-            };
-            if (fwrite(bytes, 1, 4, out) != 4) {
-                LOG_ERROR("framebuffer_stream_rgba: Failed to write pixel data");
-                return 0;
-            }
-        }
-    }
+	int width = (int)fb->width;
+	int height = (int)fb->height;
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			uint32_t pixel = atomic_load(
+				&fb->color_buffer[(size_t)y * fb->width + x]);
+			unsigned char bytes[4] = {
+				(unsigned char)((pixel >> 16) & 0xFF), // R
+				(unsigned char)((pixel >> 8) & 0xFF), // G
+				(unsigned char)(pixel & 0xFF), // B
+				(unsigned char)((pixel >> 24) & 0xFF) // A
+			};
+			if (fwrite(bytes, 1, 4, out) != 4) {
+				LOG_ERROR(
+					"framebuffer_stream_rgba: Failed to write pixel data");
+				return 0;
+			}
+		}
+	}
 
-    if (fflush(out) != 0) {
-        LOG_ERROR("framebuffer_stream_rgba: Failed to flush stream");
-        return 0;
-    }
-    return 1;
+	if (fflush(out) != 0) {
+		LOG_ERROR("framebuffer_stream_rgba: Failed to flush stream");
+		return 0;
+	}
+	return 1;
 }
 
 // Enters a tile for rendering.
 void framebuffer_enter_tile(FramebufferTile *tile)
 {
-    if (!tile) {
-        LOG_ERROR("framebuffer_enter_tile: NULL tile");
-        return;
-    }
-    tls_tile = tile;
+	if (!tile) {
+		LOG_ERROR("framebuffer_enter_tile: NULL tile");
+		return;
+	}
+	tls_tile = tile;
 }
 
 // Leaves the current tile.
 void framebuffer_leave_tile(void)
 {
-    tls_tile = NULL;
+	tls_tile = NULL;
 }

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1,351 +1,388 @@
 #include "x11_window.h"
 #include "pipeline/gl_framebuffer.h"
 #include "gl_logger.h"
+#include "gl_init.h"
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XShm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
 
 struct X11Window {
-    Display *display;
-    Window window;
-    GC gc;
-    XImage *image;
-    XShmSegmentInfo shm_info; // For shared memory (optional)
-    Bool use_shm;
-    unsigned width;
-    unsigned height;
-    unsigned rshift;
-    unsigned gshift;
-    unsigned bshift;
+	Display *display;
+	Window window;
+	GC gc;
+	XImage *image;
+	XShmSegmentInfo shm_info; // For shared memory (optional)
+	Bool use_shm;
+	unsigned width;
+	unsigned height;
+	unsigned rshift;
+	unsigned gshift;
+	unsigned bshift;
 };
 
 static pthread_mutex_t x11_mutex = PTHREAD_MUTEX_INITIALIZER;
+static bool threads_initialized = false;
 
 // Creates an X11 window with the specified dimensions and title.
 X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 {
-    if (width == 0 || height == 0 || width > 16384 || height > 16384) {
-        LOG_ERROR("Invalid window dimensions: %ux%u", width, height);
-        return NULL;
-    }
+	if (width == 0 || height == 0 || width > 16384 || height > 16384) {
+		LOG_ERROR("Invalid window dimensions: %ux%u", width, height);
+		return NULL;
+	}
 
-    pthread_mutex_lock(&x11_mutex);
-    Display *dpy = XOpenDisplay(NULL);
-    if (!dpy) {
-        const char *display_env = getenv("DISPLAY");
-        LOG_ERROR("XOpenDisplay failed. DISPLAY=%s", display_env ? display_env : "unset");
-        pthread_mutex_unlock(&x11_mutex);
-        return NULL;
-    }
+	pthread_mutex_lock(&x11_mutex);
+	if (!threads_initialized) {
+		if (!XInitThreads()) {
+			LOG_WARN(
+				"XInitThreads failed; X11 may not be thread-safe");
+		}
+		threads_initialized = true;
+	}
+	Display *dpy = XOpenDisplay(NULL);
+	if (!dpy) {
+		const char *display_env = getenv("DISPLAY");
+		LOG_ERROR("XOpenDisplay failed. DISPLAY=%s",
+			  display_env ? display_env : "unset");
+		pthread_mutex_unlock(&x11_mutex);
+		return NULL;
+	}
 
-    int screen = DefaultScreen(dpy);
-    Visual *visual = DefaultVisual(dpy, screen);
-    int depth = DefaultDepth(dpy, screen);
-    Window win = XCreateSimpleWindow(dpy, RootWindow(dpy, screen), 0, 0,
-                                     width, height, 0,
-                                     BlackPixel(dpy, screen),
-                                     WhitePixel(dpy, screen));
+	int screen = DefaultScreen(dpy);
+	Visual *visual = DefaultVisual(dpy, screen);
+	int depth = DefaultDepth(dpy, screen);
+	Window win = XCreateSimpleWindow(dpy, RootWindow(dpy, screen), 0, 0,
+					 width, height, 0,
+					 BlackPixel(dpy, screen),
+					 WhitePixel(dpy, screen));
 
-    // Set window title with length limit
-    char title_buf[257];
-    if (title && strlen(title) > 256) {
-        LOG_WARN("Window title too long, truncating");
-        strncpy(title_buf, title, 256);
-        title_buf[256] = '\0';
-        XStoreName(dpy, win, title_buf);
-    } else {
-        XStoreName(dpy, win, title ? title : "microGLES");
-    }
+	// Set window title with length limit
+	char title_buf[257];
+	if (title && strlen(title) > 256) {
+		LOG_WARN("Window title too long, truncating");
+		strncpy(title_buf, title, 256);
+		title_buf[256] = '\0';
+		XStoreName(dpy, win, title_buf);
+	} else {
+		XStoreName(dpy, win, title ? title : "microGLES");
+	}
 
-    // Enable events
-    XSelectInput(dpy, win, ExposureMask | KeyPressMask | StructureNotifyMask);
-    Atom wm_delete = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
-    XSetWMProtocols(dpy, win, &wm_delete, 1);
+	// Enable events
+	XSelectInput(dpy, win,
+		     ExposureMask | KeyPressMask | StructureNotifyMask);
+	Atom wm_delete = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+	XSetWMProtocols(dpy, win, &wm_delete, 1);
 
-    GC gc = XCreateGC(dpy, win, 0, NULL);
-    XMapWindow(dpy, win);
+	GC gc = XCreateGC(dpy, win, 0, NULL);
+	XMapWindow(dpy, win);
 
-    X11Window *w = (X11Window *)malloc(sizeof(X11Window));
-    if (!w) {
-        LOG_ERROR("Failed to allocate X11Window");
-        XFreeGC(dpy, gc);
-        XDestroyWindow(dpy, win);
-        XCloseDisplay(dpy);
-        pthread_mutex_unlock(&x11_mutex);
-        return NULL;
-    }
+	X11Window *w = (X11Window *)malloc(sizeof(X11Window));
+	if (!w) {
+		LOG_ERROR("Failed to allocate X11Window");
+		XFreeGC(dpy, gc);
+		XDestroyWindow(dpy, win);
+		XCloseDisplay(dpy);
+		pthread_mutex_unlock(&x11_mutex);
+		return NULL;
+	}
 
-    // Initialize struct
-    w->display = dpy;
-    w->window = win;
-    w->gc = gc;
-    w->width = width;
-    w->height = height;
-    w->use_shm = False;
-    memset(&w->shm_info, 0, sizeof(w->shm_info));
+	// Initialize struct
+	w->display = dpy;
+	w->window = win;
+	w->gc = gc;
+	w->width = width;
+	w->height = height;
+	w->use_shm = False;
+	memset(&w->shm_info, 0, sizeof(w->shm_info));
 
-    // Check for XShm support
-    int shm_major, shm_minor;
-    Bool shm_pixmaps;
-    if (XShmQueryVersion(dpy, &shm_major, &shm_minor, &shm_pixmaps)) {
-        w->use_shm = True;
-    }
+	// Check for XShm support
+	int shm_major, shm_minor;
+	Bool shm_pixmaps;
+	if (XShmQueryVersion(dpy, &shm_major, &shm_minor, &shm_pixmaps)) {
+		w->use_shm = True;
+	}
 
-    // Allocate image data
-    char *image_data = malloc(width * height * 4);
-    if (!image_data) {
-        LOG_ERROR("Failed to allocate image data");
-        free(w);
-        XFreeGC(dpy, gc);
-        XDestroyWindow(dpy, win);
-        XCloseDisplay(dpy);
-        pthread_mutex_unlock(&x11_mutex);
-        return NULL;
-    }
+	// Allocate image data
+	char *image_data = malloc(width * height * 4);
+	if (!image_data) {
+		LOG_ERROR("Failed to allocate image data");
+		free(w);
+		XFreeGC(dpy, gc);
+		XDestroyWindow(dpy, win);
+		XCloseDisplay(dpy);
+		pthread_mutex_unlock(&x11_mutex);
+		return NULL;
+	}
 
-    // Create XImage (try XShm first)
-    if (w->use_shm) {
-        w->image = XShmCreateImage(dpy, visual, depth, ZPixmap, NULL,
-                                   &w->shm_info, width, height);
-        if (w->image) {
-            w->shm_info.shmid = shmget(IPC_PRIVATE, width * height * 4, IPC_CREAT | 0777);
-            if (w->shm_info.shmid != -1) {
-                w->shm_info.shmaddr = shmat(w->shm_info.shmid, NULL, 0);
-                if (w->shm_info.shmaddr != (char *)-1) {
-                    w->image->data = w->shm_info.shmaddr;
-                    XShmAttach(dpy, &w->shm_info);
-                } else {
-                    w->use_shm = False;
-                    XDestroyImage(w->image);
-                    w->image = NULL;
-                }
-            } else {
-                w->use_shm = False;
-                XDestroyImage(w->image);
-                w->image = NULL;
-            }
-        } else {
-            w->use_shm = False;
-        }
-    }
+	// Create XImage (try XShm first)
+	if (w->use_shm) {
+		w->image = XShmCreateImage(dpy, visual, depth, ZPixmap, NULL,
+					   &w->shm_info, width, height);
+		if (w->image) {
+			w->shm_info.shmid = shmget(IPC_PRIVATE,
+						   width * height * 4,
+						   IPC_CREAT | 0777);
+			if (w->shm_info.shmid != -1) {
+				w->shm_info.shmaddr =
+					shmat(w->shm_info.shmid, NULL, 0);
+				if (w->shm_info.shmaddr != (char *)-1) {
+					w->image->data = w->shm_info.shmaddr;
+					XShmAttach(dpy, &w->shm_info);
+				} else {
+					w->use_shm = False;
+					XDestroyImage(w->image);
+					w->image = NULL;
+				}
+			} else {
+				w->use_shm = False;
+				XDestroyImage(w->image);
+				w->image = NULL;
+			}
+		} else {
+			w->use_shm = False;
+		}
+	}
 
-    if (!w->use_shm) {
-        w->image = XCreateImage(dpy, visual, depth, ZPixmap, 0,
-                                image_data, width, height, 32, 0);
-        if (!w->image) {
-            LOG_ERROR("XCreateImage failed");
-            free(image_data);
-            free(w);
-            XFreeGC(dpy, gc);
-            XDestroyWindow(dpy, win);
-            XCloseDisplay(dpy);
-            pthread_mutex_unlock(&x11_mutex);
-            return NULL;
-        }
-    }
+	if (!w->use_shm) {
+		w->image = XCreateImage(dpy, visual, depth, ZPixmap, 0,
+					image_data, width, height, 32, 0);
+		if (!w->image) {
+			LOG_ERROR("XCreateImage failed");
+			free(image_data);
+			free(w);
+			XFreeGC(dpy, gc);
+			XDestroyWindow(dpy, win);
+			XCloseDisplay(dpy);
+			pthread_mutex_unlock(&x11_mutex);
+			return NULL;
+		}
+	}
 
-    // Validate color masks
-    if (!w->image->red_mask || !w->image->green_mask || !w->image->blue_mask) {
-        LOG_ERROR("Invalid color masks");
-        if (w->use_shm && w->image->data) {
-            XShmDetach(dpy, &w->shm_info);
-            shmdt(w->shm_info.shmaddr);
-            shmctl(w->shm_info.shmid, IPC_RMID, NULL);
-        }
-        XDestroyImage(w->image);
-        free(w);
-        XFreeGC(dpy, gc);
-        XDestroyWindow(dpy, win);
-        XCloseDisplay(dpy);
-        pthread_mutex_unlock(&x11_mutex);
-        return NULL;
-    }
+	// Validate color masks
+	if (!w->image->red_mask || !w->image->green_mask ||
+	    !w->image->blue_mask) {
+		LOG_ERROR("Invalid color masks");
+		if (w->use_shm && w->image->data) {
+			XShmDetach(dpy, &w->shm_info);
+			shmdt(w->shm_info.shmaddr);
+			shmctl(w->shm_info.shmid, IPC_RMID, NULL);
+		}
+		XDestroyImage(w->image);
+		free(w);
+		XFreeGC(dpy, gc);
+		XDestroyWindow(dpy, win);
+		XCloseDisplay(dpy);
+		pthread_mutex_unlock(&x11_mutex);
+		return NULL;
+	}
 
-    w->rshift = __builtin_ctz(w->image->red_mask);
-    w->gshift = __builtin_ctz(w->image->green_mask);
-    w->bshift = __builtin_ctz(w->image->blue_mask);
+	w->rshift = __builtin_ctz(w->image->red_mask);
+	w->gshift = __builtin_ctz(w->image->green_mask);
+	w->bshift = __builtin_ctz(w->image->blue_mask);
 
-    XFlush(dpy);
-    pthread_mutex_unlock(&x11_mutex);
-    return w;
+	XFlush(dpy);
+	pthread_mutex_unlock(&x11_mutex);
+	return w;
 }
 
 // Destroys the X11 window and its resources.
 void x11_window_destroy(X11Window *w)
 {
-    if (!w) {
-        return;
-    }
+	if (!w) {
+		return;
+	}
 
-    pthread_mutex_lock(&x11_mutex);
-    if (w->image) {
-        if (w->use_shm) {
-            XShmDetach(w->display, &w->shm_info);
-            if (w->shm_info.shmaddr) {
-                shmdt(w->shm_info.shmaddr);
-            }
-            if (w->shm_info.shmid != -1) {
-                shmctl(w->shm_info.shmid, IPC_RMID, NULL);
-            }
-        }
-        XDestroyImage(w->image);
-    }
-    if (w->gc) {
-        XFreeGC(w->display, w->gc);
-    }
-    if (w->window) {
-        XDestroyWindow(w->display, w->window);
-    }
-    if (w->display) {
-        XCloseDisplay(w->display);
-    }
-    free(w);
-    pthread_mutex_unlock(&x11_mutex);
+	pthread_mutex_lock(&x11_mutex);
+	if (w->image) {
+		if (w->use_shm) {
+			XShmDetach(w->display, &w->shm_info);
+			if (w->shm_info.shmaddr) {
+				shmdt(w->shm_info.shmaddr);
+			}
+			if (w->shm_info.shmid != -1) {
+				shmctl(w->shm_info.shmid, IPC_RMID, NULL);
+			}
+		}
+		XDestroyImage(w->image);
+	}
+	if (w->gc) {
+		XFreeGC(w->display, w->gc);
+	}
+	if (w->window) {
+		XDestroyWindow(w->display, w->window);
+	}
+	if (w->display) {
+		XCloseDisplay(w->display);
+	}
+	free(w);
+	pthread_mutex_unlock(&x11_mutex);
 }
 
 // Renders the framebuffer to the window.
 void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 {
-    if (!w || !fb) {
-        return;
-    }
+	if (!w || !fb) {
+		return;
+	}
 
-    pthread_mutex_lock(&x11_mutex);
-    unsigned width = w->width < fb->width ? w->width : fb->width;
-    unsigned height = w->height < fb->height ? w->height : fb->height;
+	pthread_mutex_lock(&x11_mutex);
+	unsigned width = w->width < fb->width ? w->width : fb->width;
+	unsigned height = w->height < fb->height ? w->height : fb->height;
 
-    // Optimize for common pixel formats
-    if (w->rshift == 0 && w->gshift == 8 && w->bshift == 16 && w->image->bits_per_pixel == 32) {
-        // Direct copy if formats match
-        for (unsigned y = 0; y < height; ++y) {
-            memcpy(w->image->data + y * w->image->bytes_per_line,
-                   fb->color_buffer + y * fb->width,
-                   width * 4);
-        }
-    } else {
-        // Per-pixel conversion
-        for (unsigned y = 0; y < height; ++y) {
-            for (unsigned x = 0; x < width; ++x) {
-                uint32_t pixel = fb->color_buffer[y * fb->width + x];
-                unsigned char r = pixel & 0xFF;
-                unsigned char g = (pixel >> 8) & 0xFF;
-                unsigned char b = (pixel >> 16) & 0xFF;
-                unsigned char *dst = (unsigned char *)w->image->data +
-                                    (y * w->image->bytes_per_line) + x * 4;
-                uint32_t out = ((uint32_t)r << w->rshift) |
-                               ((uint32_t)g << w->gshift) |
-                               ((uint32_t)b << w->bshift);
-                memcpy(dst, &out, 4);
-            }
-        }
-    }
+	// Optimize for common pixel formats
+	if (w->rshift == 0 && w->gshift == 8 && w->bshift == 16 &&
+	    w->image->bits_per_pixel == 32) {
+		// Direct copy if formats match
+		for (unsigned y = 0; y < height; ++y) {
+			memcpy(w->image->data + y * w->image->bytes_per_line,
+			       fb->color_buffer + y * fb->width, width * 4);
+		}
+	} else {
+		// Per-pixel conversion
+		for (unsigned y = 0; y < height; ++y) {
+			for (unsigned x = 0; x < width; ++x) {
+				uint32_t pixel =
+					fb->color_buffer[y * fb->width + x];
+				unsigned char r = pixel & 0xFF;
+				unsigned char g = (pixel >> 8) & 0xFF;
+				unsigned char b = (pixel >> 16) & 0xFF;
+				unsigned char *dst =
+					(unsigned char *)w->image->data +
+					(y * w->image->bytes_per_line) + x * 4;
+				uint32_t out = ((uint32_t)r << w->rshift) |
+					       ((uint32_t)g << w->gshift) |
+					       ((uint32_t)b << w->bshift);
+				memcpy(dst, &out, 4);
+			}
+		}
+	}
 
-    if (w->use_shm) {
-        XShmPutImage(w->display, w->window, w->gc, w->image, 0, 0, 0, 0, width, height, False);
-    } else {
-        XPutImage(w->display, w->window, w->gc, w->image, 0, 0, 0, 0, width, height);
-    }
-    XFlush(w->display);
-    pthread_mutex_unlock(&x11_mutex);
+	if (w->use_shm) {
+		XShmPutImage(w->display, w->window, w->gc, w->image, 0, 0, 0, 0,
+			     width, height, False);
+	} else {
+		XPutImage(w->display, w->window, w->gc, w->image, 0, 0, 0, 0,
+			  width, height);
+	}
+	XFlush(w->display);
+	pthread_mutex_unlock(&x11_mutex);
 }
 
 // Returns the X11 display.
 Display *x11_window_get_display(const X11Window *w)
 {
-    return w ? w->display : NULL;
+	return w ? w->display : NULL;
 }
 
 // Checks if the window contains non-monochrome content.
 bool x11_window_has_non_monochrome(const X11Window *w)
 {
-    if (!w) {
-        return false;
-    }
+	if (!w) {
+		return false;
+	}
 
-    pthread_mutex_lock(&x11_mutex);
-    XImage *img = XGetImage(w->display, w->window, 0, 0, w->width, w->height, AllPlanes, ZPixmap);
-    if (!img) {
-        pthread_mutex_unlock(&x11_mutex);
-        return false;
-    }
+	pthread_mutex_lock(&x11_mutex);
+	XImage *img = XGetImage(w->display, w->window, 0, 0, w->width,
+				w->height, AllPlanes, ZPixmap);
+	if (!img) {
+		pthread_mutex_unlock(&x11_mutex);
+		return false;
+	}
 
-    bool non_white = false;
-    bool non_black = false;
-    for (int y = 0; y < img->height && !(non_white && non_black); ++y) {
-        for (int x = 0; x < img->width; ++x) {
-            unsigned long p = XGetPixel(img, x, y);
-            unsigned int rgb = ((p >> 16) & 0xFF) << 16 |
-                              ((p >> 8) & 0xFF) << 8 |
-                              (p & 0xFF);
-            if (rgb != 0xFFFFFFu) {
-                non_white = true;
-            }
-            if (rgb != 0x000000u) {
-                non_black = true;
-            }
-        }
-    }
-    XDestroyImage(img);
-    pthread_mutex_unlock(&x11_mutex);
-    return non_white && non_black;
+	bool non_white = false;
+	bool non_black = false;
+	for (int y = 0; y < img->height && !(non_white && non_black); ++y) {
+		for (int x = 0; x < img->width; ++x) {
+			unsigned long p = XGetPixel(img, x, y);
+			unsigned int rgb = ((p >> 16) & 0xFF) << 16 |
+					   ((p >> 8) & 0xFF) << 8 | (p & 0xFF);
+			if (rgb != 0xFFFFFFu) {
+				non_white = true;
+			}
+			if (rgb != 0x000000u) {
+				non_black = true;
+			}
+		}
+	}
+	XDestroyImage(img);
+	pthread_mutex_unlock(&x11_mutex);
+	return non_white && non_black;
 }
 
 // Processes X11 events and updates window state.
 bool x11_window_process_events(X11Window *w, bool *should_close)
 {
-    if (!w || !should_close) {
-        return false;
-    }
+	if (!w || !should_close) {
+		return false;
+	}
 
-    pthread_mutex_lock(&x11_mutex);
-    XEvent event;
-    while (XPending(w->display)) {
-        XNextEvent(w->display, &event);
-        switch (event.type) {
-            case Expose:
-                x11_window_show_image(w, GL_get_default_framebuffer());
-                break;
-            case KeyPress:
-                if (XLookupKeysym(&event.xkey, 0) == XK_Escape) {
-                    *should_close = true;
-                }
-                break;
-            case ConfigureNotify:
-                if (w->width != event.xconfigure.width || w->height != event.xconfigure.height) {
-                    w->width = event.xconfigure.width;
-                    w->height = event.xconfigure.height;
-                    LOG_DEBUG("Window resized to %ux%u", w->width, w->height);
-                    // Resize image (simplified; ideally recreate XImage)
-                    if (w->image) {
-                        if (w->use_shm) {
-                            XShmDetach(w->display, &w->shm_info);
-                            shmdt(w->shm_info.shmaddr);
-                            shmctl(w->shm_info.shmid, IPC_RMID, NULL);
-                        }
-                        XDestroyImage(w->image);
-                        w->image = NULL;
-                    }
-                    char *image_data = malloc(w->width * w->height * 4);
-                    if (image_data) {
-                        w->image = XCreateImage(w->display, DefaultVisual(w->display, DefaultScreen(w->display)),
-                                                DefaultDepth(w->display, DefaultScreen(w->display)),
-                                                ZPixmap, 0, image_data, w->width, w->height, 32, 0);
-                        if (!w->image) {
-                            free(image_data);
-                        }
-                    }
-                }
-                break;
-            case ClientMessage:
-                if ((Atom)event.xclient.data.l[0] == XInternAtom(w->display, "WM_DELETE_WINDOW", False)) {
-                    *should_close = true;
-                }
-                break;
-        }
-    }
-    pthread_mutex_unlock(&x11_mutex);
-    return true;
+	pthread_mutex_lock(&x11_mutex);
+	XEvent event;
+	while (XPending(w->display)) {
+		XNextEvent(w->display, &event);
+		switch (event.type) {
+		case Expose:
+			x11_window_show_image(w, GL_get_default_framebuffer());
+			break;
+		case KeyPress:
+			if (XLookupKeysym(&event.xkey, 0) == XK_Escape) {
+				*should_close = true;
+			}
+			break;
+		case ConfigureNotify:
+			if (w->width != event.xconfigure.width ||
+			    w->height != event.xconfigure.height) {
+				w->width = event.xconfigure.width;
+				w->height = event.xconfigure.height;
+				LOG_DEBUG("Window resized to %ux%u", w->width,
+					  w->height);
+				// Resize image (simplified; ideally recreate XImage)
+				if (w->image) {
+					if (w->use_shm) {
+						XShmDetach(w->display,
+							   &w->shm_info);
+						shmdt(w->shm_info.shmaddr);
+						shmctl(w->shm_info.shmid,
+						       IPC_RMID, NULL);
+					}
+					XDestroyImage(w->image);
+					w->image = NULL;
+				}
+				char *image_data =
+					malloc(w->width * w->height * 4);
+				if (image_data) {
+					w->image = XCreateImage(
+						w->display,
+						DefaultVisual(
+							w->display,
+							DefaultScreen(
+								w->display)),
+						DefaultDepth(
+							w->display,
+							DefaultScreen(
+								w->display)),
+						ZPixmap, 0, image_data,
+						w->width, w->height, 32, 0);
+					if (!w->image) {
+						free(image_data);
+					}
+				}
+			}
+			break;
+		case ClientMessage:
+			if ((Atom)event.xclient.data.l[0] ==
+			    XInternAtom(w->display, "WM_DELETE_WINDOW",
+					False)) {
+				*should_close = true;
+			}
+			break;
+		}
+	}
+	pthread_mutex_unlock(&x11_mutex);
+	return true;
 }


### PR DESCRIPTION
## Summary
- init X threads once and warn on failure
- add GL_finish/GL_swap_buffers helpers
- clean up framebuffer tile initialization
- include logger in GLX and disable unused double buffer flag

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68586ca2f5a48325830ca22289bf5e96