### PR TITLE
Improve perf_monitor logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cmake --build build
 Set `MICROGLES_THREADS` to specify the number of worker threads (defaults to the
 number of online CPUs).
 
-To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count.
+To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count. Run `perf_monitor --help` for available options such as `--profile` and `--log-level=<lvl>`.
 
 ### Debug / Sanitizer
 

--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -167,7 +167,11 @@ static bool check_fb_content(const Framebuffer *fb)
 
 static void usage(const char *prog)
 {
-	printf("Usage: %s [--profile]\n", prog);
+	printf("Usage: %s [--profile] [--log-level=<lvl>] [--help]\n", prog);
+	printf("  --profile           Enable per-thread profiling.\n");
+	printf("  --log-level=<lvl>   Set log level: debug, info, warn,\n");
+	printf("                      error, or fatal. Default is info.\n");
+	printf("  --help              Show this help and exit.\n");
 	printf("Set MICROGLES_THREADS to control worker thread count.\n");
 }
 
@@ -177,7 +181,10 @@ int main(int argc, char **argv)
 	bool profile = false;
 	for (int i = 1; i < argc; ++i) {
 		const char *arg = argv[i];
-		if (strcmp(arg, "--profile") == 0) {
+		if (strcmp(arg, "--help") == 0) {
+			usage(argv[0]);
+			return 0;
+		} else if (strcmp(arg, "--profile") == 0) {
 			profile = true;
 		} else if (strncmp(arg, "--log-level=", 12) == 0) {
 			const char *lvl = arg + 12;

--- a/src/glx.c
+++ b/src/glx.c
@@ -155,17 +155,24 @@ void glXSwapBuffers(Display *dpy, GLXDrawable drawable)
 		char fb_path[64];
 		snprintf(fb_path, sizeof(fb_path), "framebuffer_%d.bmp",
 			 dump_counter);
-		framebuffer_write_bmp(fb, fb_path);
-		uint32_t c = framebuffer_get_pixel(fb, 0, 0);
-		LOG_INFO("Saved %s first pixel 0x%08X", fb_path, c);
+		LOG_DEBUG("Attempting to save %s", fb_path);
+		if (!framebuffer_write_bmp(fb, fb_path)) {
+			LOG_ERROR("Failed to save %s", fb_path);
+		} else {
+			uint32_t c = framebuffer_get_pixel(fb, 0, 0);
+			LOG_INFO("Saved %s first pixel 0x%08X", fb_path, c);
+		}
 
 		char win_path[64];
 		snprintf(win_path, sizeof(win_path), "window_%d.bmp",
 			 dump_counter);
-		x11_window_save_bmp(current_ctx->win, win_path);
+		LOG_DEBUG("Attempting to save %s", win_path);
+		if (!x11_window_save_bmp(current_ctx->win, win_path)) {
+			LOG_ERROR("Failed to save %s", win_path);
+		}
 		++dump_counter;
 	}
-  
+
 	x11_window_show_image(current_ctx->win, fb);
 	pthread_mutex_unlock(&ctx_mutex);
 }

--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -514,6 +514,8 @@ int framebuffer_write_bmp(const Framebuffer *fb, const char *path)
 		return 0;
 	}
 
+	LOG_DEBUG("framebuffer_write_bmp: writing %s", path);
+
 	FILE *f = fopen(path, "wb");
 	if (!f) {
 		LOG_ERROR("framebuffer_write_bmp: Failed to open %s", path);

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -318,8 +318,11 @@ bool x11_window_has_non_monochrome(const X11Window *w)
 int x11_window_save_bmp(const X11Window *w, const char *path)
 {
 	if (!w || !path) {
+		LOG_ERROR("x11_window_save_bmp: invalid arguments");
 		return 0;
 	}
+
+	LOG_DEBUG("Saving window contents to %s", path);
 
 	pthread_mutex_lock(&x11_mutex);
 	XImage *img = XGetImage(w->display, w->window, 0, 0, w->width,
@@ -355,6 +358,11 @@ int x11_window_save_bmp(const X11Window *w, const char *path)
 	}
 
 	int ret = framebuffer_write_bmp(fb, path);
+	if (!ret) {
+		LOG_ERROR("x11_window_save_bmp: failed to write %s", path);
+	} else {
+		LOG_INFO("x11_window_save_bmp: wrote %s", path);
+	}
 	framebuffer_destroy(fb);
 	XDestroyImage(img);
 	pthread_mutex_unlock(&x11_mutex);


### PR DESCRIPTION
## Summary
- document perf_monitor usage in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `timeout 3 ./build/bin/benchmark`
- `./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_685886fe3704832590e34175f7ba7d6a