### PR TITLE
Add queue diagnostics on thread pool timeout

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -313,7 +313,11 @@ int main(int argc, char **argv)
 			polys += NUM_PYRAMIDS * 6.0f;
 			pix += NUM_PYRAMIDS * 6.0f * face_pixels;
 			LOG_DEBUG("before thread_pool_wait");
-			thread_pool_wait();
+			if (!thread_pool_wait_timeout(2000)) {
+				LOG_WARN("thread_pool_wait timed out");
+				thread_pool_dump_queues();
+				thread_pool_wait();
+			}
 			LOG_DEBUG("after thread_pool_wait");
 #ifdef HAVE_X11
 			if (win) {
@@ -371,7 +375,11 @@ int main(int argc, char **argv)
 		x11_window_destroy(win);
 #endif
 	LOG_INFO("Render loop complete. Cleaning up");
-	thread_pool_wait();
+	if (!thread_pool_wait_timeout(5000)) {
+		LOG_WARN("thread pool shutdown wait timed out");
+		thread_pool_dump_queues();
+		thread_pool_wait();
+	}
 	command_buffer_shutdown();
 	thread_pool_shutdown();
 	GL_cleanup_with_framebuffer(fb);

--- a/src/gl_thread.h
+++ b/src/gl_thread.h
@@ -32,6 +32,7 @@ void thread_pool_submit(task_function_t func, void *task_data,
 			stage_tag_t stage);
 void thread_pool_wait(void);
 int thread_pool_wait_timeout(uint32_t ms);
+void thread_pool_dump_queues(void);
 void thread_pool_shutdown(void);
 
 /* Returns true if worker threads are processing tasks. */


### PR DESCRIPTION
## Summary
- log queue lengths when thread_pool_wait_timeout takes too long
- expose `thread_pool_dump_queues()` for diagnostics
- report queue state in `perf_monitor` on wait timeouts

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark` *(fails: no output)*
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68589120d0408325933fd88a1fafdda2