### PR TITLE
Fix perf_monitor render wait timeout

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -316,7 +316,11 @@ int main(int argc, char **argv)
 			if (!thread_pool_wait_timeout(2000)) {
 				LOG_WARN("thread_pool_wait timed out");
 				thread_pool_dump_queues();
-				thread_pool_wait();
+				if (!thread_pool_wait_timeout(1000)) {
+					LOG_WARN(
+						"thread_pool_wait timed out again; breaking render loop");
+					break;
+				}
 			}
 			LOG_DEBUG("after thread_pool_wait");
 #ifdef HAVE_X11


### PR DESCRIPTION
## Summary
- avoid blocking thread pool wait during rendering
- break render loop if workers are still busy after a short timeout

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build_debug/bin/renderer_conformance`
- `./build/bin/perf_monitor --log-level=info`

------
https://chatgpt.com/codex/tasks/task_e_685892e071808325a026a7b26cb5d3b1