### PR TITLE
Fix thread pool active state check

### DIFF
--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -506,7 +506,8 @@ void thread_pool_shutdown(void)
 
 bool thread_pool_active(void)
 {
-	return !atomic_load_explicit(&g_shutdown_flag, memory_order_acquire);
+	return g_worker_threads && g_local_queues && g_num_threads > 0 &&
+	       !atomic_load_explicit(&g_shutdown_flag, memory_order_acquire);
 }
 
 void thread_pool_dump_queues(void)


### PR DESCRIPTION
## Summary
- improve validation in `thread_pool_active`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build/bin/benchmark` *(fails: hangs, no output)*

------
https://chatgpt.com/codex/tasks/task_e_68589efe4f088325a205033baed96b25