### PR TITLE
Reset globals on thread pool failure

### DIFF
--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -356,6 +356,10 @@ fail:
 	free(g_texture_caches);
 	free(g_local_queues);
 	free(g_worker_threads);
+	g_worker_threads = NULL;
+	g_local_queues = NULL;
+	g_texture_caches = NULL;
+	g_num_threads = 0;
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- avoid leaving dangling globals when thread pool init fails

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `MICROGLES_THREADS=2 ./build/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_6858a1a6d3e483259e34530f81d2dda0