### PR TITLE
Update thread pool init example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,12 @@ int main(void)
     /* Infrastructure */
     logger_init(NULL, LOG_LEVEL_INFO);
     memory_tracker_init();
-    thread_pool_init_from_env(); /* uses MICROGLES_THREADS or the
-                                   number of online CPUs */
+    int threads = thread_pool_init_from_env(); /* uses MICROGLES_THREADS or the
+                                                 number of online CPUs */
+    if (threads <= 0) {
+        fputs("Failed to init thread pool\n", stderr);
+        return 1;
+    }
 #ifdef ENABLE_PROFILE
     thread_profile_start(); /* Optional: per-stage timings */
 #endif


### PR DESCRIPTION
## Summary
- clarify how to check `thread_pool_init_from_env()` return value in the quick-start example
- show simple error handling when no threads are created

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6858a322140483259eaedf5abf973457