### PR TITLE
Expose thread option in perf_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ cmake --build build
 ./build/bin/renderer_conformance
 ```
 Set `MICROGLES_THREADS` to specify the number of worker threads (defaults to the
-number of online CPUs).
+number of online CPUs). The `perf_monitor` tool starts with two threads if the
+variable is unset. Use `--threads=<n>` to override the count on the command
+line.
 
-To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count. Run `perf_monitor --help` for available options such as `--profile` and `--log-level=<lvl>`.
+To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count. Run `perf_monitor --help` for available options such as `--profile` and `--log-level=<lvl>`. The `--threads=<n>` option sets the worker count without touching the environment.
 
 ### Debug / Sanitizer
 

--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -167,8 +167,11 @@ static bool check_fb_content(const Framebuffer *fb)
 
 static void usage(const char *prog)
 {
-	printf("Usage: %s [--profile] [--log-level=<lvl>] [--help]\n", prog);
+	printf("Usage: %s [--profile] [--threads=<n>] [--log-level=<lvl>] [--help]\n",
+	       prog);
 	printf("  --profile           Enable per-thread profiling.\n");
+	printf("  --threads=<n>       Number of worker threads (overrides\n");
+	printf("                      MICROGLES_THREADS env var).\n");
 	printf("  --log-level=<lvl>   Set log level: debug, info, warn,\n");
 	printf("                      error, or fatal. Default is info.\n");
 	printf("  --help              Show this help and exit.\n");
@@ -179,6 +182,9 @@ int main(int argc, char **argv)
 {
 	LogLevel log_level = LOG_LEVEL_INFO;
 	bool profile = false;
+	const char *threads_arg = NULL;
+	if (!getenv("MICROGLES_THREADS"))
+		setenv("MICROGLES_THREADS", "2", 0);
 	for (int i = 1; i < argc; ++i) {
 		const char *arg = argv[i];
 		if (strcmp(arg, "--help") == 0) {
@@ -186,6 +192,8 @@ int main(int argc, char **argv)
 			return 0;
 		} else if (strcmp(arg, "--profile") == 0) {
 			profile = true;
+		} else if (strncmp(arg, "--threads=", 10) == 0) {
+			threads_arg = arg + 10;
 		} else if (strncmp(arg, "--log-level=", 12) == 0) {
 			const char *lvl = arg + 12;
 			if (strcmp(lvl, "debug") == 0)
@@ -200,6 +208,8 @@ int main(int argc, char **argv)
 				log_level = LOG_LEVEL_FATAL;
 		}
 	}
+	if (threads_arg)
+		setenv("MICROGLES_THREADS", threads_arg, 1);
 	if (!logger_init("perf_monitor.log", log_level)) {
 		fprintf(stderr, "Failed to initialize logger.\n");
 		return -1;


### PR DESCRIPTION
## Summary
- allow overriding worker count via `--threads=<n>` in perf_monitor
- set default thread count to 2 when `MICROGLES_THREADS` is unset
- document new option and update usage text

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6858a89de1008325a05df24c867dde38