### PR TITLE
Fix SHM image_data leak

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -133,6 +133,8 @@ X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 				if (w->shm_info.shmaddr != (char *)-1) {
 					w->image->data = w->shm_info.shmaddr;
 					XShmAttach(dpy, &w->shm_info);
+					free(image_data);
+					image_data = NULL;
 				} else {
 					w->use_shm = False;
 					XDestroyImage(w->image);
@@ -161,6 +163,7 @@ X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 			pthread_mutex_unlock(&x11_mutex);
 			return NULL;
 		}
+		image_data = NULL;
 	}
 
 	// Validate color masks
@@ -173,6 +176,7 @@ X11Window *x11_window_create(unsigned width, unsigned height, const char *title)
 			shmctl(w->shm_info.shmid, IPC_RMID, NULL);
 		}
 		XDestroyImage(w->image);
+		free(image_data);
 		free(w);
 		XFreeGC(dpy, gc);
 		XDestroyWindow(dpy, win);


### PR DESCRIPTION
## Summary
- free temporary image_data after using XShm in x11_window_create
- null image_data after creating non-shm XImage
- free image_data on failure before returning

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake --build build --target format`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68592dbcc5fc832583bea3495b5bd1b1