### PR TITLE
Fix X11 color copy and process events each frame

### DIFF
--- a/src/glx.c
+++ b/src/glx.c
@@ -174,6 +174,8 @@ void glXSwapBuffers(Display *dpy, GLXDrawable drawable)
 	}
 
 	x11_window_show_image(current_ctx->win, fb);
+	bool dummy_close = false;
+	x11_window_process_events(current_ctx->win, &dummy_close);
 	pthread_mutex_unlock(&ctx_mutex);
 }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -235,7 +235,7 @@ void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 	unsigned height = w->height < fb->height ? w->height : fb->height;
 
 	// Optimize for common pixel formats
-	if (w->rshift == 0 && w->gshift == 8 && w->bshift == 16 &&
+	if (w->rshift == 16 && w->gshift == 8 && w->bshift == 0 &&
 	    w->image->bits_per_pixel == 32) {
 		// Direct copy if formats match
 		for (unsigned y = 0; y < height; ++y) {
@@ -248,9 +248,9 @@ void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 			for (unsigned x = 0; x < width; ++x) {
 				uint32_t pixel =
 					fb->color_buffer[y * fb->width + x];
-				unsigned char r = pixel & 0xFF;
+				unsigned char r = (pixel >> 16) & 0xFF;
 				unsigned char g = (pixel >> 8) & 0xFF;
-				unsigned char b = (pixel >> 16) & 0xFF;
+				unsigned char b = pixel & 0xFF;
 				unsigned char *dst =
 					(unsigned char *)w->image->data +
 					(y * w->image->bytes_per_line) + x * 4;

--- a/src/x11_window.h
+++ b/src/x11_window.h
@@ -16,5 +16,6 @@ void x11_window_show_image(X11Window *win, const struct Framebuffer *fb);
 Display *x11_window_get_display(const X11Window *win);
 bool x11_window_has_non_monochrome(const X11Window *win);
 int x11_window_save_bmp(const X11Window *win, const char *path);
+bool x11_window_process_events(X11Window *win, bool *should_close);
 
 #endif /* X11_WINDOW_H */


### PR DESCRIPTION
## Summary
- correct RGB to X11 pixel shift in `x11_window_show_image`
- export `x11_window_process_events` and call it in `glXSwapBuffers`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build_debug/bin/renderer_conformance`


------
https://chatgpt.com/codex/tasks/task_e_68592db88a9483258e78d14f1c772227