### PR TITLE
Fix color mask handling in window check

### DIFF
--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -298,17 +298,23 @@ bool x11_window_has_non_monochrome(const X11Window *w)
 		return false;
 	}
 
+	unsigned rshift = __builtin_ctz(img->red_mask);
+	unsigned gshift = __builtin_ctz(img->green_mask);
+	unsigned bshift = __builtin_ctz(img->blue_mask);
+
 	bool non_white = false;
 	bool non_black = false;
 	for (int y = 0; y < img->height && !(non_white && non_black); ++y) {
-		for (int x = 0; x < img->width; ++x) {
+		for (int x = 0; x < img->width && !(non_white && non_black);
+		     ++x) {
 			unsigned long p = XGetPixel(img, x, y);
-			unsigned int rgb = ((p >> 16) & 0xFF) << 16 |
-					   ((p >> 8) & 0xFF) << 8 | (p & 0xFF);
-			if (rgb != 0xFFFFFFu) {
+			unsigned char r = (p & img->red_mask) >> rshift;
+			unsigned char g = (p & img->green_mask) >> gshift;
+			unsigned char b = (p & img->blue_mask) >> bshift;
+			if (r != 0xFF || g != 0xFF || b != 0xFF) {
 				non_white = true;
 			}
-			if (rgb != 0x000000u) {
+			if (r != 0x00 || g != 0x00 || b != 0x00) {
 				non_black = true;
 			}
 		}


### PR DESCRIPTION
## Summary
- handle custom red/green/blue masks in `x11_window_has_non_monochrome`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68593205f4188325ba0536707cfb4d7f