### PR TITLE
Fix alignment bug in object pool

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -7,7 +7,15 @@
 struct PoolNode {
 	struct PoolNode *next_free;
 	struct PoolNode *next_all;
+	/* Padding ensures that the following object allocation begins on a
+         * 64-byte boundary.  This avoids misaligned accesses when the object
+         * itself requires 64 byte alignment (e.g. VertexJob).  The exact size
+         * is computed so that sizeof(struct PoolNode) == 64 on both 32 and
+         * 64 bit builds.
+         */
+	unsigned char padding[64 - 2 * sizeof(void *)];
 };
+_Static_assert(sizeof(struct PoolNode) == 64, "PoolNode must be 64 bytes");
 
 struct ObjectPool {
 	struct PoolNode *free_list;


### PR DESCRIPTION
## Summary
- ensure that pool allocations for VertexJob and others remain 64-byte aligned
- add padding and static assert for `PoolNode`

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build_debug/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_685931d665548325ab3298f3d468552c