### PR TITLE
Increase perf_monitor wait threshold

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -323,14 +323,11 @@ int main(int argc, char **argv)
 			polys += NUM_PYRAMIDS * 6.0f;
 			pix += NUM_PYRAMIDS * 6.0f * face_pixels;
 			LOG_DEBUG("before thread_pool_wait");
-			if (!thread_pool_wait_timeout(2000)) {
-				LOG_WARN("thread_pool_wait timed out");
+			if (!thread_pool_wait_timeout(5000)) {
+				LOG_WARN(
+					"thread_pool_wait timed out; dumping queues and aborting");
 				thread_pool_dump_queues();
-				if (!thread_pool_wait_timeout(1000)) {
-					LOG_WARN(
-						"thread_pool_wait timed out again; breaking render loop");
-					break;
-				}
+				break;
 			}
 			LOG_DEBUG("after thread_pool_wait");
 #ifdef HAVE_X11


### PR DESCRIPTION
## Summary
- bump the wait timeout in `perf_monitor` to 5 seconds
- dump thread queues once before aborting

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`
- `./build/bin/perf_monitor` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_685932105b4c832599e2dc59a1e11740