### PR TITLE
Update Profiling docs for stage logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ Systems without a cycle counter treat the value as nanoseconds. When
 `__builtin_readcyclecounter` is available, the profiler calibrates CPU
 frequency on first use so reported times are approximations.
 
+Debug logging can also trace each pipeline phase. Initialize the logger with
+`LOG_LEVEL_DEBUG` or pass `--log-level=debug` on the command line to emit
+messages when stages start and finish. Run `stage_logging_demo --log-level=debug`
+to watch the vertex through framebuffer stages execute in sequence.
+
 ### Linking as a Static Library
 
 Build only the library if you want to embed microGLES in another project:


### PR DESCRIPTION
## Summary
- document the new per-stage debug logging demo in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `ASAN_OPTIONS=halt_on_error=1 ./build_debug/bin/renderer_conformance`
- `cmake --build build --target format`

------
https://chatgpt.com/codex/tasks/task_e_68593693346083258cfc7fbef11e758b