### PR TITLE
Add detailed debug logging across pipeline stages

### DIFF
--- a/src/pipeline/gl_fragment.c
+++ b/src/pipeline/gl_fragment.c
@@ -288,6 +288,8 @@ void process_fragment_job(void *task_data)
 void process_fragment_tile_job(void *task_data)
 {
 	FragmentTileJob *job = (FragmentTileJob *)task_data;
+	LOG_DEBUG("Fragment tile (%u,%u)-(%u,%u) mode=%s", job->x0, job->y0,
+		  job->x1, job->y1, job->sprite_mode ? "sprite" : "triangle");
 	uint32_t w = job->x1 - job->x0 + 1;
 	uint32_t h = job->y1 - job->y0 + 1;
 

--- a/src/pipeline/gl_framebuffer.c
+++ b/src/pipeline/gl_framebuffer.c
@@ -299,6 +299,7 @@ void framebuffer_set_pixel(Framebuffer *restrict fb, uint32_t x, uint32_t y,
 	if (!fb || x >= fb->width || y >= fb->height) {
 		return;
 	}
+	LOG_DEBUG("set_pixel (%u,%u) color=0x%08X", x, y, color);
 
 	_Atomic uint32_t *color_buffer = fb->color_buffer;
 	_Atomic float *depth_buffer = fb->depth_buffer;
@@ -481,6 +482,8 @@ void framebuffer_fill_rect(Framebuffer *fb, uint32_t x0, uint32_t y0,
 		LOG_ERROR("framebuffer_fill_rect: Invalid parameters");
 		return;
 	}
+	LOG_DEBUG("fill_rect (%u,%u)-(%u,%u) color=0x%08X", x0, y0, x1, y1,
+		  color);
 	for (uint32_t y = y0; y <= y1; ++y) {
 		for (uint32_t x = x0; x <= x1; ++x) {
 			framebuffer_set_pixel(fb, x, y, color, depth);

--- a/src/pipeline/gl_primitive.c
+++ b/src/pipeline/gl_primitive.c
@@ -1,5 +1,6 @@
 #include "gl_primitive.h"
 #include "gl_raster.h"
+#include "../gl_logger.h"
 #include "../gl_thread.h"
 #include "../pool.h"
 #define PIPELINE_USE_GLSTATE 0
@@ -24,10 +25,16 @@ void process_primitive_job(void *task_data)
 	Triangle tri;
 	pipeline_assemble_triangle(&tri, &job->verts[0], &job->verts[1],
 				   &job->verts[2]);
+	LOG_DEBUG(
+		"Triangle assembled: v0(%.2f,%.2f,%.2f) v1(%.2f,%.2f,%.2f) v2(%.2f,%.2f,%.2f)",
+		tri.v0.x, tri.v0.y, tri.v0.z, tri.v1.x, tri.v1.y, tri.v1.z,
+		tri.v2.x, tri.v2.y, tri.v2.z);
 	if (edge(&tri.v0, &tri.v1, &tri.v2) <= 0.f) {
+		LOG_DEBUG("Triangle culled due to backface");
 		MT_FREE(job, STAGE_PRIMITIVE);
 		return; // culled
 	}
+	LOG_DEBUG("Triangle accepted for rasterization");
 	RasterJob *rjob = raster_job_acquire();
 	if (!rjob) {
 		MT_FREE(job, STAGE_PRIMITIVE);

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -77,6 +77,10 @@ void pipeline_rasterize_triangle(const Triangle *restrict tri,
 	}
 	if (iminx > imaxx || iminy > imaxy)
 		return;
+	int tiles_x = (imaxx - iminx) / TILE_SIZE + 1;
+	int tiles_y = (imaxy - iminy) / TILE_SIZE + 1;
+	LOG_DEBUG("Raster tri BB [%d,%d]-[%d,%d], %d tiles", iminx, iminy,
+		  imaxx, imaxy, tiles_x * tiles_y);
 	uint32_t color = pack_color(tri->v0.color);
 	for (int ty = iminy; ty <= imaxy; ty += TILE_SIZE) {
 		for (int tx = iminx; tx <= imaxx; tx += TILE_SIZE) {
@@ -149,6 +153,10 @@ void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
 	}
 	if (x0 > x1 || y0 > y1)
 		return;
+	int ptiles_x = (x1 - x0) / TILE_SIZE + 1;
+	int ptiles_y = (y1 - y0) / TILE_SIZE + 1;
+	LOG_DEBUG("Raster point BB [%d,%d]-[%d,%d], %d tiles", x0, y0, x1, y1,
+		  ptiles_x * ptiles_y);
 	uint32_t color = pack_color(v->color);
 	for (int ty = y0; ty <= y1; ty += TILE_SIZE) {
 		for (int tx = x0; tx <= x1; tx += TILE_SIZE) {

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -1,6 +1,7 @@
 #include "gl_vertex.h"
 #include "gl_primitive.h"
 #include "../gl_context.h"
+#include "../gl_logger.h"
 #define PIPELINE_USE_GLSTATE 0
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
@@ -160,6 +161,15 @@ void process_vertex_job(void *task_data)
 	apply_lighting(&v0);
 	apply_lighting(&v1);
 	apply_lighting(&v2);
+	LOG_DEBUG("Vertex0: (%.2f, %.2f, %.2f, %.2f) col(%.2f %.2f %.2f %.2f)",
+		  v0.x, v0.y, v0.z, v0.w, v0.color[0], v0.color[1], v0.color[2],
+		  v0.color[3]);
+	LOG_DEBUG("Vertex1: (%.2f, %.2f, %.2f, %.2f) col(%.2f %.2f %.2f %.2f)",
+		  v1.x, v1.y, v1.z, v1.w, v1.color[0], v1.color[1], v1.color[2],
+		  v1.color[3]);
+	LOG_DEBUG("Vertex2: (%.2f, %.2f, %.2f, %.2f) col(%.2f %.2f %.2f %.2f)",
+		  v2.x, v2.y, v2.z, v2.w, v2.color[0], v2.color[1], v2.color[2],
+		  v2.color[3]);
 	PrimitiveJob *pjob = MT_ALLOC(sizeof(PrimitiveJob), STAGE_PRIMITIVE);
 	if (!pjob)
 		return;


### PR DESCRIPTION
## Summary
- log final vertex positions and colors in `process_vertex_job`
- report triangle assembly and culling in `process_primitive_job`
- show raster bounds and tile count for triangles and points
- indicate fragment tile coordinates and mode before shading
- note pixel and rectangle writes in framebuffer functions

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68593678b07483258b932a4e4113dd9d