### PR TITLE
Add TILESIZE env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ No SIMD intrinsics or platform APIs are required; only a C11 toolchain is needed
 | **Utilities**       | ✔ `load_ktx_texture()` helper and GLU-style matrix wrappers |
 | **Framebuffer**     | ✔ RGBA8 + 32-bit float depth, atomic CAS writes, morton-swizzled layout |
 | **Threading**       | ✔ Lock-free MPMC queue, built-in command buffer recorder, per-stage profiling (`--profile`) |
-| **Pipeline**        | ✔ 16×16 tiled fragment stage, 4×4 texture block cache                |
+| **Pipeline**        | ✔ Configurable tiled fragment stage (default 16×16), 4×4 texture block cache |
 | **State model**     | ✔ Versioned `RenderContext`; worker threads clone only dirtied chunks. RenderContext holds all dynamic flags (see `docs/migration/state.md`) |
 | **Diagnostics**     | ✔ Early-init memory tracker, async logger, built-in perf counters    |
 | **Tooling**         | ✔ Release + ASAN builds, style check (`clang-format`), benchmarks, conformance harness |
@@ -64,7 +64,8 @@ cmake --build build
 Set `MICROGLES_THREADS` to specify the number of worker threads (defaults to the
 number of online CPUs). The `perf_monitor` tool starts with two threads if the
 variable is unset. Use `--threads=<n>` to override the count on the command
-line.
+line. Set `TILESIZE` (or pass `--tilesize=<n|fb>`) to control the rendering tile
+size; `fb` uses one tile for the entire framebuffer.
 
 To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count. Run `perf_monitor --help` for available options such as `--profile` and `--log-level=<lvl>`. The `--threads=<n>` option sets the worker count without touching the environment.
 The `stage_logging_demo` executable draws a triangle with verbose logs and writes `stage_demo.bmp`; run `./build/bin/stage_logging_demo` after building.
@@ -211,7 +212,7 @@ API thread
   │ gl_primitive.c   Assemble, cull, clip
   │              │
   │              ▼
-  │ gl_raster.c      Edge functions, emit 16×16 tile jobs
+  │ gl_raster.c      Edge functions, emit tile jobs (size from TILESIZE)
   │              │
   │              ▼
   │ gl_fragment.c    Shade tile buffer, texturing, fog, blend

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,8 @@ int main(int argc, char **argv)
 			win_w = (unsigned)atoi(argv[i] + 8);
 		else if (strncmp(argv[i], "--height=", 9) == 0)
 			win_h = (unsigned)atoi(argv[i] + 9);
+		else if (strncmp(argv[i], "--tilesize=", 11) == 0)
+			setenv("TILESIZE", argv[i] + 11, 1);
 	}
 	/* Initialize Logger */
 	if (!logger_init("renderer.log", LOG_LEVEL_DEBUG)) {

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -77,17 +77,17 @@ void pipeline_rasterize_triangle(const Triangle *restrict tri,
 	}
 	if (iminx > imaxx || iminy > imaxy)
 		return;
-	int tiles_x = (imaxx - iminx) / TILE_SIZE + 1;
-	int tiles_y = (imaxy - iminy) / TILE_SIZE + 1;
+	int tiles_x = (imaxx - iminx) / fb->tile_size + 1;
+	int tiles_y = (imaxy - iminy) / fb->tile_size + 1;
 	LOG_DEBUG("Raster tri BB [%d,%d]-[%d,%d], %d tiles", iminx, iminy,
 		  imaxx, imaxy, tiles_x * tiles_y);
 	uint32_t color = pack_color(tri->v0.color);
-	for (int ty = iminy; ty <= imaxy; ty += TILE_SIZE) {
-		for (int tx = iminx; tx <= imaxx; tx += TILE_SIZE) {
-			int ex = tx + TILE_SIZE - 1;
+	for (int ty = iminy; ty <= imaxy; ty += fb->tile_size) {
+		for (int tx = iminx; tx <= imaxx; tx += fb->tile_size) {
+			int ex = tx + fb->tile_size - 1;
 			if (ex > imaxx)
 				ex = imaxx;
-			int ey = ty + TILE_SIZE - 1;
+			int ey = ty + fb->tile_size - 1;
 			if (ey > imaxy)
 				ey = imaxy;
 			FragmentTileJob *jobt = tile_job_acquire();
@@ -153,17 +153,17 @@ void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
 	}
 	if (x0 > x1 || y0 > y1)
 		return;
-	int ptiles_x = (x1 - x0) / TILE_SIZE + 1;
-	int ptiles_y = (y1 - y0) / TILE_SIZE + 1;
+	int ptiles_x = (x1 - x0) / fb->tile_size + 1;
+	int ptiles_y = (y1 - y0) / fb->tile_size + 1;
 	LOG_DEBUG("Raster point BB [%d,%d]-[%d,%d], %d tiles", x0, y0, x1, y1,
 		  ptiles_x * ptiles_y);
 	uint32_t color = pack_color(v->color);
-	for (int ty = y0; ty <= y1; ty += TILE_SIZE) {
-		for (int tx = x0; tx <= x1; tx += TILE_SIZE) {
-			int ex = tx + TILE_SIZE - 1;
+	for (int ty = y0; ty <= y1; ty += fb->tile_size) {
+		for (int tx = x0; tx <= x1; tx += fb->tile_size) {
+			int ex = tx + fb->tile_size - 1;
 			if (ex > x1)
 				ex = x1;
-			int ey = ty + TILE_SIZE - 1;
+			int ey = ty + fb->tile_size - 1;
 			if (ey > y1)
 				ey = y1;
 			FragmentTileJob *jobt = tile_job_acquire();

--- a/src/pipeline/gl_raster.h
+++ b/src/pipeline/gl_raster.h
@@ -16,8 +16,6 @@ void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
 			      const GLint *restrict viewport,
 			      Framebuffer *restrict fb);
 
-#define TILE_SIZE 16
-
 typedef struct {
 	alignas(64) uint32_t x0, y0, x1, y1;
 	uint32_t color;


### PR DESCRIPTION
## Summary
- support runtime-configurable tile size via TILESIZE env or `--tilesize`
- allocate framebuffer tiles dynamically and track tile size per framebuffer
- adjust raster and fragment stages to use the tile size
- document the new option in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `ASAN_OPTIONS=halt_on_error=1 ./build_debug/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6859396e61008325947b37b8dccbad6e