### PR TITLE
Improve debug logging with colored stage/frame markers

### DIFF
--- a/benchmark/src/perf_monitor.c
+++ b/benchmark/src/perf_monitor.c
@@ -305,6 +305,7 @@ int main(int argc, char **argv)
 		cstart = thread_get_cycles();
 		double polys = 0.0, pix = 0.0;
 		do {
+			LOG_FRAME_START(frame_idx);
 			LOG_DEBUG("before render_scene");
 			render_scene();
 			LOG_DEBUG("after render_scene");

--- a/src/gl_logger.c
+++ b/src/gl_logger.c
@@ -16,6 +16,7 @@ static _Alignas(64) atomic_uint_fast64_t g_head;
 static _Alignas(64) atomic_uint_fast64_t g_tail;
 static atomic_uint g_dropped;
 static FILE *g_file;
+static _Thread_local unsigned g_indent;
 
 static void log_output_char(char c)
 {
@@ -123,6 +124,11 @@ void logger_shutdown(void)
 	}
 }
 
+void logger_set_indent(unsigned level)
+{
+	g_indent = level;
+}
+
 void LogMessage(LogLevel level, const char *format, ...)
 {
 	if (level < g_level)
@@ -140,6 +146,10 @@ void LogMessage(LogLevel level, const char *format, ...)
 	get_timestamp(ts, sizeof(ts));
 	int off = snprintf(msg, MESSAGE_SIZE, "[%s] [%s] ", ts,
 			   level_string(level));
+	for (unsigned i = 0; i < g_indent && off + 2 < MESSAGE_SIZE; ++i) {
+		msg[off++] = ' ';
+		msg[off++] = ' ';
+	}
 	va_list args;
 	va_start(args, format);
 	vsnprintf(msg + off, MESSAGE_SIZE - off, format, args);

--- a/src/gl_logger.h
+++ b/src/gl_logger.h
@@ -31,12 +31,34 @@ typedef enum {
 int logger_init(const char *path, LogLevel level);
 void logger_shutdown(void);
 void LogMessage(LogLevel level, const char *format, ...);
+void logger_set_indent(unsigned level);
 
 #define LOG_DEBUG(...) LogMessage(LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define LOG_INFO(...) LogMessage(LOG_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARN(...) LogMessage(LOG_LEVEL_WARN, __VA_ARGS__)
 #define LOG_ERROR(...) LogMessage(LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_FATAL(...) LogMessage(LOG_LEVEL_FATAL, __VA_ARGS__)
+
+#ifndef NDEBUG
+#define ANSI_YELLOW "\x1b[33m"
+#define ANSI_GREEN "\x1b[32m"
+#define ANSI_RESET "\x1b[0m"
+#define LOG_FRAME_START(idx)                                                  \
+	do {                                                                  \
+		logger_set_indent(0);                                         \
+		LogMessage(LOG_LEVEL_INFO, ANSI_YELLOW "Frame %d" ANSI_RESET, \
+			   (idx));                                            \
+	} while (0)
+#define LOG_STAGE_START(name)                                          \
+	do {                                                           \
+		LogMessage(LOG_LEVEL_INFO, ANSI_GREEN "%s" ANSI_RESET, \
+			   (name));                                    \
+		logger_set_indent(1);                                  \
+	} while (0)
+#else
+#define LOG_FRAME_START(idx) ((void)0)
+#define LOG_STAGE_START(name) ((void)0)
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/gl_thread.c
+++ b/src/gl_thread.c
@@ -573,7 +573,7 @@ void thread_profile_report(void)
 			if (pd->max_task_cycles > t_max_cycles)
 				t_max_cycles = pd->max_task_cycles;
 		}
-		LOG_INFO("Stage %s:", stage_names[stage]);
+		LOG_STAGE_START(stage_names[stage]);
 		LOG_INFO("  Total Tasks: %llu", t_tasks);
 		LOG_INFO("  Total Steal Attempts: %llu", t_attempts);
 		LOG_INFO("  Total Steal Successes: %llu", t_steals);
@@ -593,6 +593,7 @@ void thread_profile_report(void)
 			 thread_cycles_to_us(t_idle_cycles));
 		LOG_INFO("  Total Steal Time: %llu us",
 			 thread_cycles_to_us(t_steal_cycles));
+		logger_set_indent(0);
 	}
 	uint64_t g_tasks = 0, g_steals = 0, g_attempts = 0, g_contention = 0;
 	uint64_t g_task_cycles = 0, g_idle_cycles = 0, g_steal_cycles = 0,


### PR DESCRIPTION
## Summary
- extend logger with indent control and colored macros
- mark frame and stage starts in benchmark and thread pool

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `./build_debug/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_68594a20932883259148733016d5a8b7