### PR TITLE
Add framebuffer ref counting for pipeline jobs

### DIFF
--- a/src/gl_api_draw.c
+++ b/src/gl_api_draw.c
@@ -7,6 +7,7 @@
 #include "pool.h"
 #include "pipeline/gl_vertex.h"
 #include "pipeline/gl_raster.h"
+#include "pipeline/gl_framebuffer.h"
 #include "matrix_utils.h"
 #include "gl_thread.h"
 #include "function_profile.h"
@@ -256,6 +257,7 @@ GL_API void GL_APIENTRY glDrawArrays(GLenum mode, GLint first, GLsizei count)
 			}
 		}
 		job->fb = fb;
+		framebuffer_retain(job->fb);
 		command_buffer_record_task(process_vertex_job, job,
 					   STAGE_VERTEX);
 	}
@@ -512,6 +514,7 @@ GL_API void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type,
 			}
 		}
 		job->fb = fb;
+		framebuffer_retain(job->fb);
 		command_buffer_record_task(process_vertex_job, job,
 					   STAGE_VERTEX);
 	}

--- a/src/pipeline/gl_fragment.c
+++ b/src/pipeline/gl_fragment.c
@@ -356,5 +356,6 @@ void process_fragment_tile_job(void *task_data)
 		       w * sizeof(uint8_t));
 	}
 	atomic_flag_clear(&tile->lock);
+	framebuffer_release(job->fb);
 	tile_job_release(job);
 }

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -100,6 +100,7 @@ void pipeline_rasterize_triangle(const Triangle *restrict tri,
 			jobt->color = color;
 			jobt->depth = tri->v0.z;
 			jobt->fb = fb;
+			framebuffer_retain(jobt->fb);
 			jobt->sprite_mode = GL_FALSE;
 			thread_pool_submit(process_fragment_tile_job, jobt,
 					   STAGE_FRAGMENT);
@@ -176,6 +177,7 @@ void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
 			jobt->color = color;
 			jobt->depth = v->z;
 			jobt->fb = fb;
+			framebuffer_retain(jobt->fb);
 			jobt->sprite_mode = GL_TRUE;
 			jobt->sprite_cx = v->x;
 			jobt->sprite_cy = v->y;
@@ -190,5 +192,6 @@ void process_raster_job(void *task_data)
 {
 	RasterJob *job = (RasterJob *)task_data;
 	pipeline_rasterize_triangle(&job->tri, job->viewport, job->fb);
+	framebuffer_release(job->fb);
 	raster_job_release(job);
 }

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -171,13 +171,18 @@ void process_vertex_job(void *task_data)
 		  v2.x, v2.y, v2.z, v2.w, v2.color[0], v2.color[1], v2.color[2],
 		  v2.color[3]);
 	PrimitiveJob *pjob = MT_ALLOC(sizeof(PrimitiveJob), STAGE_PRIMITIVE);
-	if (!pjob)
+	if (!pjob) {
+		framebuffer_release(job->fb);
+		vertex_job_release(job);
 		return;
+	}
 	pjob->verts[0] = v0;
 	pjob->verts[1] = v1;
 	pjob->verts[2] = v2;
 	pjob->fb = job->fb;
+	framebuffer_retain(pjob->fb);
 	memcpy(pjob->viewport, job->viewport, sizeof(job->viewport));
+	framebuffer_release(job->fb);
 	vertex_job_release(job);
 	thread_pool_submit(process_primitive_job, pjob, STAGE_PRIMITIVE);
 }


### PR DESCRIPTION
## Summary
- retain framebuffer when creating pipeline jobs
- release framebuffer after job processing

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68596b108ea48325b528c415f7c95446