### PR TITLE
Fix color layout in frame operations

### DIFF
--- a/src/gl_api_pixels.c
+++ b/src/gl_api_pixels.c
@@ -60,9 +60,9 @@ GL_API void GL_APIENTRY glReadPixels(GLint x, GLint y, GLsizei width,
 				fb, (uint32_t)(x + i), (uint32_t)(y + j));
 			uint8_t *dst =
 				(uint8_t *)pixels + (size_t)(j * width + i) * 4;
-			dst[0] = c & 0xFF;
+			dst[0] = (c >> 16) & 0xFF;
 			dst[1] = (c >> 8) & 0xFF;
-			dst[2] = (c >> 16) & 0xFF;
+			dst[2] = c & 0xFF;
 			dst[3] = (c >> 24) & 0xFF;
 		}
 	}

--- a/src/pipeline/gl_fragment.c
+++ b/src/pipeline/gl_fragment.c
@@ -17,19 +17,23 @@ _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 
 static uint32_t modulate(uint32_t a, uint32_t c)
 {
-	uint8_t ar = a & 0xFF;
+	/* Colors are stored as AARRGGBB */
+	uint8_t ar = (a >> 16) & 0xFF;
 	uint8_t ag = (a >> 8) & 0xFF;
-	uint8_t ab = (a >> 16) & 0xFF;
+	uint8_t ab = a & 0xFF;
 	uint8_t aa = (a >> 24) & 0xFF;
-	uint8_t br = c & 0xFF;
+
+	uint8_t br = (c >> 16) & 0xFF;
 	uint8_t bg = (c >> 8) & 0xFF;
-	uint8_t bb = (c >> 16) & 0xFF;
+	uint8_t bb = c & 0xFF;
 	uint8_t ba = (c >> 24) & 0xFF;
+
 	uint8_t r = (ar * br) / 255;
 	uint8_t g = (ag * bg) / 255;
 	uint8_t b = (ab * bb) / 255;
 	uint8_t aout = (aa * ba) / 255;
-	return r | (g << 8) | (b << 16) | ((uint32_t)aout << 24);
+	return ((uint32_t)aout << 24) | ((uint32_t)r << 16) |
+	       ((uint32_t)g << 8) | (uint32_t)b;
 }
 static _Thread_local TextureState local_tex[2];
 static _Thread_local unsigned local_tex_ver[2];

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -14,7 +14,9 @@ static uint32_t pack_color(const GLfloat c[4])
 	uint8_t g = (uint8_t)(c[1] * 255.0f + 0.5f);
 	uint8_t b = (uint8_t)(c[2] * 255.0f + 0.5f);
 	uint8_t a = (uint8_t)(c[3] * 255.0f + 0.5f);
-	return (a << 24) | (b << 16) | (g << 8) | r;
+	/* Store colors in AARRGGBB layout */
+	return ((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) |
+	       (uint32_t)b;
 }
 
 void pipeline_rasterize_triangle(const Triangle *restrict tri,

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -268,9 +268,9 @@ void x11_window_show_image(X11Window *w, const struct Framebuffer *fb)
 			for (unsigned x = 0; x < width; ++x) {
 				uint32_t pixel =
 					fb->color_buffer[y * fb->width + x];
-				unsigned char r = pixel & 0xFF;
+				unsigned char r = (pixel >> 16) & 0xFF;
 				unsigned char g = (pixel >> 8) & 0xFF;
-				unsigned char b = (pixel >> 16) & 0xFF;
+				unsigned char b = pixel & 0xFF;
 				unsigned char *dst =
 					(unsigned char *)w->image->data +
 					(y * w->image->bytes_per_line) + x * 4;


### PR DESCRIPTION
## Summary
- store framebuffer colors as AARRGGBB consistently
- correct color modulation and extraction logic
- adjust per-pixel conversions for readback and X11 output

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68597f573c008325a364ec0f9d1a4ed6