### PR TITLE
Fix color pipeline format

### DIFF
--- a/src/gl_api_pixels.c
+++ b/src/gl_api_pixels.c
@@ -24,9 +24,9 @@ GL_API void GL_APIENTRY glClear(GLbitfield mask)
 	if (fb) {
 		uint32_t color =
 			((uint32_t)(gl_state.clear_color[3] * 255.0f) << 24) |
-			((uint32_t)(gl_state.clear_color[2] * 255.0f) << 16) |
+			((uint32_t)(gl_state.clear_color[0] * 255.0f) << 16) |
 			((uint32_t)(gl_state.clear_color[1] * 255.0f) << 8) |
-			((uint32_t)(gl_state.clear_color[0] * 255.0f));
+			((uint32_t)(gl_state.clear_color[2] * 255.0f));
 		framebuffer_clear_async(fb, color, gl_state.clear_depth,
 					(uint8_t)gl_state.clear_stencil);
 	}


### PR DESCRIPTION
## Summary
- fix byte order in `glClear`
- align texture color storage with framebuffer layout
- remove out-of-bounds fog blending and adjust color math
- handle blending and texture sampling with consistent AARRGGBB format

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `timeout 5 ./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_68598a4d9fd083258ba6102ad2843cd9