### PR TITLE
Add PLUGIN_REGISTER helper

### DIFF
--- a/src/plugin.h
+++ b/src/plugin.h
@@ -12,6 +12,21 @@ typedef void (*stage_plugin_fn)(void *job);
 void plugin_register(stage_tag_t stage, stage_plugin_fn fn);
 void plugin_invoke(stage_tag_t stage, void *job);
 
+/**
+ * Convenience macro to auto-register a plugin at load time.
+ *
+ * Example:
+ * @code
+ * static void my_plugin(void *job) { do_work(job); }
+ * PLUGIN_REGISTER(STAGE_VERTEX, my_plugin);
+ * @endcode
+ */
+#define PLUGIN_REGISTER(stage, func)                                    \
+	static void __attribute__((constructor)) _register_##func(void) \
+	{                                                               \
+		plugin_register(stage, func);                           \
+	}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- add PLUGIN_REGISTER macro for automatically registering plugins
- document macro usage in plugin.h

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `timeout 10 ./build/bin/renderer_conformance >/tmp/test.log` (fails: 26/28 tests passed)


------
https://chatgpt.com/codex/tasks/task_e_6859b442e1c883258602cbd3292ed694