### PR TITLE
Add plugin hook calls in pipeline

### DIFF
--- a/src/pipeline/gl_fragment.c
+++ b/src/pipeline/gl_fragment.c
@@ -7,6 +7,7 @@
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
 #include "../pool.h"
+#include "../plugin.h"
 #include "../gl_types.h"
 #include "gl_framebuffer.h"
 #include "gl_raster.h"
@@ -288,6 +289,7 @@ void pipeline_shade_fragment(Fragment *frag, Framebuffer *fb)
 void process_fragment_job(void *task_data)
 {
 	FragmentJob *job = (FragmentJob *)task_data;
+	plugin_invoke(STAGE_FRAGMENT, job);
 	pipeline_shade_fragment(&job->frag, job->fb);
 	MT_FREE(job, STAGE_FRAGMENT);
 }
@@ -295,6 +297,7 @@ void process_fragment_job(void *task_data)
 void process_fragment_tile_job(void *task_data)
 {
 	FragmentTileJob *job = (FragmentTileJob *)task_data;
+	plugin_invoke(STAGE_FRAGMENT, job);
 	LOG_DEBUG("Fragment tile (%u,%u)-(%u,%u) mode=%s", job->x0, job->y0,
 		  job->x1, job->y1, job->sprite_mode ? "sprite" : "triangle");
 	uint32_t w = job->x1 - job->x0 + 1;

--- a/src/pipeline/gl_primitive.c
+++ b/src/pipeline/gl_primitive.c
@@ -3,6 +3,7 @@
 #include "../gl_logger.h"
 #include "../gl_thread.h"
 #include "../pool.h"
+#include "../plugin.h"
 #define PIPELINE_USE_GLSTATE 0
 _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
@@ -22,6 +23,7 @@ static float edge(const Vertex *a, const Vertex *b, const Vertex *c)
 void process_primitive_job(void *task_data)
 {
 	PrimitiveJob *job = (PrimitiveJob *)task_data;
+	plugin_invoke(STAGE_PRIMITIVE, job);
 	Triangle tri;
 	pipeline_assemble_triangle(&tri, &job->verts[0], &job->verts[1],
 				   &job->verts[2]);

--- a/src/pipeline/gl_raster.c
+++ b/src/pipeline/gl_raster.c
@@ -7,6 +7,7 @@ _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
 #include "../gl_thread.h"
 #include "../pool.h"
+#include "../plugin.h"
 
 static uint32_t pack_color(const GLfloat c[4])
 {
@@ -193,6 +194,7 @@ void pipeline_rasterize_point(const Vertex *restrict v, GLfloat size,
 void process_raster_job(void *task_data)
 {
 	RasterJob *job = (RasterJob *)task_data;
+	plugin_invoke(STAGE_RASTER, job);
 	pipeline_rasterize_triangle(&job->tri, job->viewport, job->fb);
 	framebuffer_release(job->fb);
 	raster_job_release(job);

--- a/src/pipeline/gl_vertex.c
+++ b/src/pipeline/gl_vertex.c
@@ -7,6 +7,7 @@ _Static_assert(PIPELINE_USE_GLSTATE == 0, "pipeline must not touch gl_state");
 #include "../gl_memory_tracker.h"
 #include "../gl_thread.h"
 #include "../pool.h"
+#include "../plugin.h"
 #include <string.h>
 #include "../c11_opt.h"
 #include "../matrix_utils.h"
@@ -133,6 +134,7 @@ static void apply_lighting(Vertex *v)
 void process_vertex_job(void *task_data)
 {
 	VertexJob *job = (VertexJob *)task_data;
+	plugin_invoke(STAGE_VERTEX, job);
 	RenderContext *ctx = GetCurrentContext();
 	unsigned mv = atomic_load(&ctx->version_modelview);
 	unsigned pr = atomic_load(&ctx->version_projection);


### PR DESCRIPTION
## Summary
- trigger plugin_invoke at start of each stage job
- include `plugin.h` in the pipeline implementations

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`

------
https://chatgpt.com/codex/tasks/task_e_6859b760e3248325a564b82d6125f3af