### PR TITLE
Add example vertex shader plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCE_FILES
     src/texture_cache.c
     src/function_profile.c
     plugins/ktx_decoder.c
+    plugins/vertex_shader_1_1.c
     src/command_buffer.c
     src/x11_window.c
     src/glx.c

--- a/plugins/vertex_shader_1_1.c
+++ b/plugins/vertex_shader_1_1.c
@@ -1,0 +1,36 @@
+#include "plugin.h"
+#include "pipeline/gl_vertex.h"
+#include "gl_context.h"
+#include "matrix_utils.h"
+
+static void vertex_shader_1_1(void *job)
+{
+	VertexJob *vj = (VertexJob *)job;
+	if (!vj)
+		return;
+
+	RenderContext *ctx = GetCurrentContext();
+	if (!ctx)
+		return;
+
+	mat4 mvp;
+	mat4_multiply(&mvp, &ctx->projection_matrix, &ctx->modelview_matrix);
+
+	for (int i = 0; i < 3; ++i) {
+		Vertex *v = &vj->in[i];
+		GLfloat in[4] = { v->x, v->y, v->z, v->w };
+		GLfloat out[4];
+		mat4_transform_vec4(&mvp, in, out);
+		GLfloat inv_w = out[3] != 0.0f ? 1.0f / out[3] : 1.0f;
+		GLfloat ndc_x = out[0] * inv_w;
+		GLfloat ndc_y = out[1] * inv_w;
+		GLfloat ndc_z = out[2] * inv_w;
+		v->color[0] = ndc_x * 0.5f + 0.5f;
+		v->color[1] = ndc_y * 0.5f + 0.5f;
+		v->color[2] = ndc_z * 0.5f + 0.5f;
+	}
+}
+
+PLUGIN_REGISTER(STAGE_VERTEX, vertex_shader_1_1)
+
+int vertex_shader_1_1_link;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -12,6 +12,9 @@ static int g_dec_count;
 
 extern int ktx_decoder_link;
 static void *volatile force_link_ktx __attribute__((used)) = &ktx_decoder_link;
+extern int vertex_shader_1_1_link;
+static void *volatile force_link_vs
+	__attribute__((used)) = &vertex_shader_1_1_link;
 
 void plugin_register(stage_tag_t stage, stage_plugin_fn fn)
 {


### PR DESCRIPTION
## Summary
- implement a simple vertex stage plugin `vertex_shader_1_1`
- force link new plugin in `plugin.c`
- compile plugin via CMake

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/benchmark` *(fails: no output)*
- `./build/bin/renderer_conformance` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859c5c39ed08325bb7f58f9c7d9c0c0