### PR TITLE
Add fragment shader plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCE_FILES
     src/function_profile.c
     plugins/ktx_decoder.c
     plugins/vertex_shader_1_1.c
+    plugins/pixel_shader_1_3.c
     src/command_buffer.c
     src/x11_window.c
     src/glx.c

--- a/plugins/pixel_shader_1_3.c
+++ b/plugins/pixel_shader_1_3.c
@@ -1,0 +1,35 @@
+#include "plugin.h"
+#include "pipeline/gl_fragment.h"
+#include "gl_thread.h"
+#include <stdint.h>
+
+static void noop_task(void *data)
+{
+	(void)data;
+}
+
+static void pixel_shader_1_3(void *job)
+{
+	if (!job)
+		return;
+
+	FragmentJob *fj = (FragmentJob *)job;
+	if (!fj->fb)
+		return; /* likely a tile job */
+
+	Fragment *f = &fj->frag;
+	uint8_t r = (f->color >> 16) & 0xFF;
+	uint8_t g = (f->color >> 8) & 0xFF;
+	uint8_t b = f->color & 0xFF;
+	uint8_t a = (f->color >> 24) & 0xFF;
+	uint8_t gray = (uint8_t)((r + g + b) / 3);
+	f->color = ((uint32_t)a << 24) | ((uint32_t)gray << 16) |
+		   ((uint32_t)gray << 8) | gray;
+
+	if (f->x == 0 && f->y == 0)
+		thread_pool_submit(noop_task, NULL, STAGE_FRAGMENT);
+}
+
+PLUGIN_REGISTER(STAGE_FRAGMENT, pixel_shader_1_3)
+
+int pixel_shader_1_3_link;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -15,6 +15,9 @@ static void *volatile force_link_ktx __attribute__((used)) = &ktx_decoder_link;
 extern int vertex_shader_1_1_link;
 static void *volatile force_link_vs
 	__attribute__((used)) = &vertex_shader_1_1_link;
+extern int pixel_shader_1_3_link;
+static void *volatile force_link_ps
+	__attribute__((used)) = &pixel_shader_1_3_link;
 
 void plugin_register(stage_tag_t stage, stage_plugin_fn fn)
 {


### PR DESCRIPTION
## Summary
- implement `pixel_shader_1_3` plugin for the fragment stage
- register the new plugin in the plugin manager
- build it via CMake

## Testing
- `cmake --build build`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance` (partial log shown)

------
https://chatgpt.com/codex/tasks/task_e_6859c8ff19788325bad29c422bfd3254