### PR TITLE
Add plugin_submit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Each stage increments its own profiling counters (`thread_profile_report()`).
 - Follow **AGENTS.md** (build, test, clang-format, conformance pass).
 - Keep each `gl_api_*.c` focused on a single spec chapter.
 - Prefer `MT_ALLOC/MT_FREE` and `thread_pool_submit()` over raw `malloc/thrd_create`.
+- Stage plugins may call `plugin_submit()` to spawn extra work items.
 - Document non-obvious algorithms (e.g., atomic depth CAS loop) inline.
 - See [`docs/PORTABILITY.md`](docs/PORTABILITY.md) for cross-platform guidelines.
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -41,6 +41,11 @@ void plugin_invoke(stage_tag_t stage, void *job)
 	}
 }
 
+void plugin_submit(task_function_t fn, void *data, stage_tag_t stage)
+{
+	thread_pool_submit(fn, data, stage);
+}
+
 void texture_decoder_register(texture_decoder_fn fn)
 {
 	if (!fn)

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -13,6 +13,14 @@ typedef void (*stage_plugin_fn)(void *job);
 void plugin_register(stage_tag_t stage, stage_plugin_fn fn);
 void plugin_invoke(stage_tag_t stage, void *job);
 
+/**
+ * Submit a task to the internal thread pool from a plugin.
+ *
+ * Stage plugins may call this helper to spawn additional work items.
+ * It simply forwards the request to `thread_pool_submit`.
+ */
+void plugin_submit(task_function_t fn, void *data, stage_tag_t stage);
+
 typedef int (*texture_decoder_fn)(const char *file, GLuint *tex);
 void texture_decoder_register(texture_decoder_fn fn);
 GLuint texture_decode(const char *file);


### PR DESCRIPTION
## Summary
- add `plugin_submit` wrapper around `thread_pool_submit`
- update plugin docs in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/benchmark --no-window` *(fails: no output)*
- `./build/bin/renderer_conformance` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859d0af80708325b5407ffadc0a37c6