### PR TITLE
Expose plugin names and report in extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No SIMD intrinsics or platform APIs are required; only a C11 toolchain is needed
 |---------------------|----------------------------------------------------------------------|
 | **Fixed-function core** | ✔ Matrix stacks, lighting (8 lights), fog, 2-unit texturing, alpha-test, depth & stencil, blending, scissor, point/line primitives |
 | **Extensions**      | ✔ `OES_framebuffer_object`, `OES_draw_texture`, `OES_point_sprite`, `OES_point_size_array`, `OES_matrix_palette` (stubs for others) |
-| **Utilities**       | ✔ pluggable `texture_decode()` helper and GLU-style matrix wrappers |
+| **Utilities**       | ✔ pluggable `texture_decode()` helper, `plugin_list()` and GLU-style matrix wrappers |
 | **Framebuffer**     | ✔ ARGB8888/XRGB8888 + 32-bit float depth, atomic CAS writes, morton-swizzled layout |
 | **Threading**       | ✔ Lock-free MPMC queue, built-in command buffer recorder, per-stage profiling (`--profile`) |
 | **Pipeline**        | ✔ Configurable tiled fragment stage (default 16×16), 4×4 texture block cache |
@@ -170,6 +170,13 @@ int main(void)
 Compile with `-DENABLE_PROFILE` or run any program with `--profile` to record per-stage timings. Without the flag, tasks still execute but no profiling counters are recorded.
 Set `MICROGLES_THREADS` to override the default thread count (number of online
 CPUs).
+
+## Plugins
+
+Plugins extend the renderer at runtime. Built-in modules register themselves
+automatically via `PLUGIN_REGISTER`. Call `plugin_list()` to retrieve a
+space-separated string of active plugin identifiers. The value is also appended
+to the list returned by `renderer_get_extensions()`.
 
 ## Profiling
 

--- a/src/extensions/gl_extensions.c
+++ b/src/extensions/gl_extensions.c
@@ -3,9 +3,11 @@
 #include "gl_types.h"
 #include "gl_utils.h"
 #include "gl_logger.h"
+#include "plugin.h"
 #include <GLES/gl.h>
 #include <GLES/glext.h>
 #include <string.h>
+#include <stdio.h>
 #include <math.h>
 
 /* Tokens missing from the ES headers used by TexGen */
@@ -75,7 +77,13 @@ static TextureOES *find_texture(GLuint id)
 
 const GLubyte *renderer_get_extensions(void)
 {
-	return (const GLubyte *)EXT_STRING;
+	static char buf[512];
+	const char *plugins = plugin_list();
+	if (plugins && plugins[0] != '\0')
+		snprintf(buf, sizeof(buf), "%s %s", EXT_STRING, plugins);
+	else
+		snprintf(buf, sizeof(buf), "%s", EXT_STRING);
+	return (const GLubyte *)buf;
 }
 
 static void draw_tex_rect(GLfloat x, GLfloat y, GLfloat z, GLfloat width,

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -1,9 +1,11 @@
 #include "plugin.h"
 #include <stddef.h>
+#include <string.h>
 
 #define MAX_PLUGINS_PER_STAGE 4
 
 static stage_plugin_fn g_plugins[STAGE_COUNT][MAX_PLUGINS_PER_STAGE];
+static const char *g_plugin_names[STAGE_COUNT][MAX_PLUGINS_PER_STAGE];
 static int g_plugin_count[STAGE_COUNT];
 
 #define MAX_TEXTURE_DECODERS 4
@@ -19,13 +21,14 @@ extern int pixel_shader_1_3_link;
 static void *volatile force_link_ps
 	__attribute__((used)) = &pixel_shader_1_3_link;
 
-void plugin_register(stage_tag_t stage, stage_plugin_fn fn)
+void plugin_register(stage_tag_t stage, stage_plugin_fn fn, const char *name)
 {
-	if (!fn || stage < 0 || stage >= STAGE_COUNT)
+	if (!fn || !name || stage < 0 || stage >= STAGE_COUNT)
 		return;
 	int count = g_plugin_count[stage];
 	if (count < MAX_PLUGINS_PER_STAGE) {
 		g_plugins[stage][count] = fn;
+		g_plugin_names[stage][count] = name;
 		g_plugin_count[stage] = count + 1;
 	}
 }
@@ -58,4 +61,30 @@ GLuint texture_decode(const char *file)
 			return tex;
 	}
 	return 0;
+}
+
+const char *plugin_list(void)
+{
+	static char list[256];
+	size_t pos = 0;
+	list[0] = '\0';
+	for (int s = 0; s < STAGE_COUNT; ++s) {
+		for (int i = 0; i < g_plugin_count[s]; ++i) {
+			const char *name = g_plugin_names[s][i];
+			if (!name)
+				continue;
+			size_t len = strlen(name);
+			if (pos != 0 && pos + 1 < sizeof(list))
+				list[pos++] = ' ';
+			if (pos + len >= sizeof(list))
+				return list; /* truncate */
+			memcpy(&list[pos], name, len);
+			pos += len;
+		}
+	}
+	if (pos < sizeof(list))
+		list[pos] = '\0';
+	else
+		list[sizeof(list) - 1] = '\0';
+	return list;
 }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -10,7 +10,8 @@ extern "C" {
 
 typedef void (*stage_plugin_fn)(void *job);
 
-void plugin_register(stage_tag_t stage, stage_plugin_fn fn);
+const char *plugin_list(void);
+void plugin_register(stage_tag_t stage, stage_plugin_fn fn, const char *name);
 void plugin_invoke(stage_tag_t stage, void *job);
 
 typedef int (*texture_decoder_fn)(const char *file, GLuint *tex);
@@ -31,7 +32,7 @@ extern int ktx_decoder_link;
 #define PLUGIN_REGISTER(stage, func)                                    \
 	static void __attribute__((constructor)) _register_##func(void) \
 	{                                                               \
-		plugin_register(stage, func);                           \
+		plugin_register(stage, func, #func);                    \
 	}
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- add `plugin_list()` and store names upon plugin registration
- expose plugin names through `renderer_get_extensions`
- document plugins in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `cmake --build build --target format`
- `./build/bin/renderer_conformance` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859d2f0779c8325a950f45c578e8fb9