### PR TITLE
Add stage logging demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ variable is unset. Use `--threads=<n>` to override the count on the command
 line.
 
 To gather per-stage timings at runtime, pass `--profile` to the benchmark or conformance executables. The stress_test program also accepts `--profile` for analyzing the million-cube scene. Pass `--stream-fb` to stress_test to pipe the framebuffer as raw RGBA to stdout for tools like `ffmpeg`. Use `--x11-window --width=640 --height=480` to display the framebuffer in an X11 window. The command buffer recorder is always enabled, so no extra build flags are required. The `perf_monitor` tool shows CPU and memory usage while spinning 1,000 pyramids; set `MICROGLES_THREADS` to adjust the worker thread count. Run `perf_monitor --help` for available options such as `--profile` and `--log-level=<lvl>`. The `--threads=<n>` option sets the worker count without touching the environment.
+The `stage_logging_demo` executable draws a triangle with verbose logs and writes `stage_demo.bmp`; run `./build/bin/stage_logging_demo` after building.
 
 ### Debug / Sanitizer
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -21,6 +21,22 @@ set(BENCH_SOURCES
 
 add_executable(benchmark ${BENCH_SOURCES})
 
+add_executable(stage_logging_demo
+    src/stage_logging_demo.c
+)
+
+target_include_directories(stage_logging_demo PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(stage_logging_demo PRIVATE renderer_lib pthread m)
+
+set_target_properties(stage_logging_demo PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
 add_executable(stress_test
     src/stress_test.c
     src/benchmark.c

--- a/benchmark/src/stage_logging_demo.c
+++ b/benchmark/src/stage_logging_demo.c
@@ -1,0 +1,51 @@
+#include "gl_state.h"
+#include "gl_init.h"
+#include "gl_logger.h"
+#include "gl_memory_tracker.h"
+#include "gl_thread.h"
+#include "command_buffer.h"
+#include <GLES/gl.h>
+
+int main(void)
+{
+	if (!logger_init("stage_logging_demo.log", LOG_LEVEL_DEBUG)) {
+		return -1;
+	}
+	if (!memory_tracker_init()) {
+		LOG_FATAL("Failed to initialize Memory Tracker.");
+		return -1;
+	}
+	if (!thread_pool_init_from_env()) {
+		LOG_FATAL("Failed to init thread pool");
+		return -1;
+	}
+	command_buffer_init();
+	InitGLState(&gl_state);
+	Framebuffer *fb = GL_init_with_framebuffer(256, 256);
+	if (!fb) {
+		LOG_FATAL("Failed to create framebuffer");
+		return -1;
+	}
+
+	GLfloat verts[] = { -0.5f, -0.5f, 0.0f, 0.5f, -0.5f,
+			    0.0f,  0.0f,  0.5f, 0.0f };
+	GLfloat colors[] = { 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f,
+			     0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f };
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_COLOR_ARRAY);
+	glVertexPointer(3, GL_FLOAT, 0, verts);
+	glColorPointer(4, GL_FLOAT, 0, colors);
+	glDrawArrays(GL_TRIANGLES, 0, 3);
+
+	thread_pool_wait();
+	framebuffer_write_bmp(fb, "stage_demo.bmp");
+
+	command_buffer_shutdown();
+	thread_pool_shutdown();
+	GL_cleanup_with_framebuffer(fb);
+	CleanupGLState(&gl_state);
+	memory_tracker_shutdown();
+	memory_tracker_report();
+	logger_shutdown();
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add `stage_logging_demo` sample program
- build the new example in benchmark CMake
- document demo usage in README

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11 -O3 -ftree-vectorize"`
- `cmake --build build`
- `cmake -S . -B build_debug -DCMAKE_C_FLAGS="-std=gnu11 -Og -g -fsanitize=undefined,address"`
- `cmake --build build_debug`
- `./build/bin/renderer_conformance`
- `cmake --build build --target format`


------
https://chatgpt.com/codex/tasks/task_e_6859368d87d48325b7320f8ec4a3d0c2